### PR TITLE
Add missing comma to products JS code

### DIFF
--- a/source/includes/wp-api-v2/_products.md
+++ b/source/includes/wp-api-v2/_products.md
@@ -557,7 +557,7 @@ var data = {
         'Black',
         'Green'
       ]
-    }
+    },
     {
       name: 'Size',
       position: 0,


### PR DESCRIPTION
There is a missing comma in the products section.