### PR TITLE
Add Google Analytics tracking to layout.

### DIFF
--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -46,6 +46,15 @@ under the License.
     <% else %>
       <%= javascript_include_tag  "all_nosearch" %>
     <% end %>
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8KCYZ2CYMS"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8KCYZ2CYMS');
+    </script>
   </head>
 
   <body class="<%= page_classes %><% if current_page.data.warning %> has-warning<% end %>" data-languages="<%=h language_tabs.map{ |lang| lang.is_a?(Hash) ? lang.keys.first : lang }.to_json %>">


### PR DESCRIPTION
This PR adds a Google Analytics tracking tag to the base layout that will help us measure traffic and engagement for the pages in this resource.

I tested this out locally and it seems to be working, but I'm not sure if there is anything else I need to do to make sure it deploys to the gh-pages branch in this repo. 😃