### PR TITLE
Add 'modified_before', 'modified_after' and 'dates_are_gmt' parameters.

### DIFF
--- a/source/includes/wp-api-v3/_coupons.md
+++ b/source/includes/wp-api-v3/_coupons.md
@@ -392,20 +392,23 @@ woocommerce.get("coupons").parsed_response
 
 #### Available parameters ####
 
-| Parameter  | Type    | Description                                                                                                                  |
-| ---------- | ------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| `context`  | string  | Scope under which the request is made; determines fields present in response. Options: `view` and `edit`. Default is `view`. |
-| `page`     | integer | Current page of the collection. Default is `1`.                                                                              |
-| `per_page` | integer | Maximum number of items to be returned in result set. Default is `10`.                                                       |
-| `search`   | string  | Limit results to those matching a string.                                                                                    |
-| `after`    | string  | Limit response to resources published after a given ISO8601 compliant date.                                                  |
-| `before`   | string  | Limit response to resources published before a given ISO8601 compliant date.                                                 |
-| `exclude`  | array   | Ensure result set excludes specific IDs.                                                                                     |
-| `include`  | array   | Limit result set to specific ids.                                                                                            |
-| `offset`   | integer | Offset the result set by a specific number of items.                                                                         |
-| `order`    | string  | Order sort attribute ascending or descending. Options: `asc` and `desc`. Default is `desc`.                                  |
-| `orderby`  | string  | Sort collection by object attribute. Options: `date`, `id`, `include`, `title` and `slug`. Default is `date`.                |
-| `code`     | string  | Limit result set to resources with a specific code.                                                                          |
+| Parameter         | Type    | Description                                                                                                                  |
+| ----------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `context`         | string  | Scope under which the request is made; determines fields present in response. Options: `view` and `edit`. Default is `view`. |
+| `page`            | integer | Current page of the collection. Default is `1`.                                                                              |
+| `per_page`        | integer | Maximum number of items to be returned in result set. Default is `10`.                                                       |
+| `search`          | string  | Limit results to those matching a string.                                                                                    |
+| `after`           | string  | Limit response to resources published after a given ISO8601 compliant date.                                                  |
+| `before`          | string  | Limit response to resources published before a given ISO8601 compliant date.                                                 |
+| `modified_after`  | string  | Limit response to resources modified after a given ISO8601 compliant date.                                                   |
+| `modified_before` | string  | Limit response to resources modified after a given ISO8601 compliant date.                                                   |
+| `dates_are_gmt`   | boolean | Whether to consider GMT post dates when limiting response by published or modified date.                                     |
+| `exclude`         | array   | Ensure result set excludes specific IDs.                                                                                     |
+| `include`         | array   | Limit result set to specific ids.                                                                                            |
+| `offset`          | integer | Offset the result set by a specific number of items.                                                                         |
+| `order`           | string  | Order sort attribute ascending or descending. Options: `asc` and `desc`. Default is `desc`.                                  |
+| `orderby`         | string  | Sort collection by object attribute. Options: `date`, `id`, `include`, `title` and `slug`. Default is `date`.                |
+| `code`            | string  | Limit result set to resources with a specific code.                                                                          |
 
 ## Update a coupon ##
 

--- a/source/includes/wp-api-v3/_orders.md
+++ b/source/includes/wp-api-v3/_orders.md
@@ -1187,25 +1187,28 @@ woocommerce.get("orders").parsed_response
 
 #### Available parameters ####
 
-| Parameter        | Type    | Description                                                                                                                                                                              |
-|------------------|---------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `context`        | string  | Scope under which the request is made; determines fields present in response. Options: `view` and `edit`. Default is `view`.                                                             |
-| `page`           | integer | Current page of the collection. Default is `1`.                                                                                                                                          |
-| `per_page`       | integer | Maximum number of items to be returned in result set. Default is `10`.                                                                                                                   |
-| `search`         | string  | Limit results to those matching a string.                                                                                                                                                |
-| `after`          | string  | Limit response to resources published after a given ISO8601 compliant date.                                                                                                              |
-| `before`         | string  | Limit response to resources published before a given ISO8601 compliant date.                                                                                                             |
-| `exclude`        | array   | Ensure result set excludes specific IDs.                                                                                                                                                 |
-| `include`        | array   | Limit result set to specific ids.                                                                                                                                                        |
-| `offset`         | integer | Offset the result set by a specific number of items.                                                                                                                                     |
-| `order`          | string  | Order sort attribute ascending or descending. Options: `asc` and `desc`. Default is `desc`.                                                                                              |
-| `orderby`        | string  | Sort collection by object attribute. Options: `date`, `id`, `include`, `title` and `slug`. Default is `date`.                                                                            |
-| `parent`         | array   | Limit result set to those of particular parent IDs.                                                                                                                                      |
-| `parent_exclude` | array   | Limit result set to all items except those of a particular parent ID.                                                                                                                    |
-| `status`         | array   | Limit result set to orders assigned a specific status. Options: `any`, `pending`, `processing`, `on-hold`, `completed`, `cancelled`, `refunded`, `failed` and `trash`. Default is `any`. |
-| `customer`       | integer | Limit result set to orders assigned a specific customer.                                                                                                                                 |
-| `product`        | integer | Limit result set to orders assigned a specific product.                                                                                                                                  |
-| `dp`             | integer | Number of decimal points to use in each resource. Default is `2`.                                                                                                                        |
+| Parameter         | Type    | Description                                                                                                                              |
+|-------------------|---------|------------------------------------------------------------------------------------------------------------------------------------------|
+| `context`         | string  | Scope under which the request is made; determines fields present in response. Options: `view` and `edit`. Default is `view`.             |
+| `page`            | integer | Current page of the collection. Default is `1`.                                                                                          |
+| `per_page`        | integer | Maximum number of items to be returned in result set. Default is `10`.                                                                   |
+| `search`          | string  | Limit results to those matching a string.                                                                                                |
+| `after`           | string  | Limit response to resources published after a given ISO8601 compliant date.                                                              |
+| `before`          | string  | Limit response to resources published before a given ISO8601 compliant date.                                                             |
+| `modified_after`  | string  | Limit response to resources modified after a given ISO8601 compliant date.                                                               |
+| `modified_before` | string  | Limit response to resources modified after a given ISO8601 compliant date.                                                               |
+| `dates_are_gmt`   | boolean | Whether to consider GMT post dates when limiting response by published or modified date.                                                 |
+| `exclude`         | array   | Ensure result set excludes specific IDs.                                                                                                 |
+| `include`         | array   | Limit result set to specific ids.                                                                                                        |
+| `offset`          | integer | Offset the result set by a specific number of items.                                                                                     |
+| `order`           | string  | Order sort attribute ascending or descending. Options: `asc` and `desc`. Default is `desc`.                                              |
+| `orderby`         | string  | Sort collection by object attribute. Options: `date`, `id`, `include`, `title` and `slug`. Default is `date`.                            |
+| `parent`          | array   | Limit result set to those of particular parent IDs.                                                                                      |
+| `parent_exclude`  | array   | Limit result set to all items except those of a particular parent ID.                                                                    |
+| `status`          | array   | Limit result set to orders assigned a specific status. Options: `any`, `pending`, `processing`, `on-hold`, `completed`, `cancelled`, `refunded`, `failed` and `trash`. Default is `any`. |
+| `customer`        | integer | Limit result set to orders assigned a specific customer.                                                                                 |
+| `product`         | integer | Limit result set to orders assigned a specific product.                                                                                  |
+| `dp`              | integer | Number of decimal points to use in each resource. Default is `2`.                                                                        |
 
 ## Update an Order ##
 

--- a/source/includes/wp-api-v3/_products.md
+++ b/source/includes/wp-api-v3/_products.md
@@ -1461,36 +1461,39 @@ woocommerce.get("products").parsed_response
 
 #### Available parameters ####
 
-| Parameter        | Type    | Description                                                                                                                             |
-|------------------|---------|-----------------------------------------------------------------------------------------------------------------------------------------|
-| `context`        | string  | Scope under which the request is made; determines fields present in response. Options: `view` and `edit`. Default is `view`.            |
-| `page`           | integer | Current page of the collection. Default is `1`.                                                                                         |
-| `per_page`       | integer | Maximum number of items to be returned in result set. Default is `10`.                                                                  |
-| `search`         | string  | Limit results to those matching a string.                                                                                               |
-| `after`          | string  | Limit response to resources published after a given ISO8601 compliant date.                                                             |
-| `before`         | string  | Limit response to resources published before a given ISO8601 compliant date.                                                            |
-| `exclude`        | array   | Ensure result set excludes specific IDs.                                                                                                |
-| `include`        | array   | Limit result set to specific ids.                                                                                                       |
-| `offset`         | integer | Offset the result set by a specific number of items.                                                                                    |
-| `order`          | string  | Order sort attribute ascending or descending. Options: `asc` and `desc`. Default is `desc`.                                             |
-| `orderby`        | string  | Sort collection by object attribute. Options: `date`, `id`, `include`, `title`, `slug`, `price`, `popularity` and `rating`. Default is `date`.                           |
-| `parent`         | array   | Limit result set to those of particular parent IDs.                                                                                     |
-| `parent_exclude` | array   | Limit result set to all items except those of a particular parent ID.                                                                   |
-| `slug`           | string  | Limit result set to products with a specific slug.                                                                                      |
-| `status`         | string  | Limit result set to products assigned a specific status. Options: `any`, `draft`, `pending`, `private` and `publish`. Default is `any`. |
-| `type`           | string  | Limit result set to products assigned a specific type. Options: `simple`, `grouped`, `external` and `variable`.                         |
-| `sku`            | string  | Limit result set to products with a specific SKU.                                                                                       |
-| `featured`       | boolean | Limit result set to featured products.                                                                                                  |
-| `category`       | string  | Limit result set to products assigned a specific category ID.                                                                           |
-| `tag`            | string  | Limit result set to products assigned a specific tag ID.                                                                                |
-| `shipping_class` | string  | Limit result set to products assigned a specific shipping class ID.                                                                     |
-| `attribute`      | string  | Limit result set to products with a specific attribute.                                                                                 |
-| `attribute_term` | string  | Limit result set to products with a specific attribute term ID (required an assigned attribute).                                        |
-| `tax_class`      | string  | Limit result set to products with a specific tax class. Default options: `standard`, `reduced-rate` and `zero-rate`.                    |
-| `on_sale`        | boolean | Limit result set to products on sale.                                                                                                   |
-| `min_price`      | string  | Limit result set to products based on a minimum price.                                                                                  |
-| `max_price`      | string  | Limit result set to products based on a maximum price.                                                                                  |
-| `stock_status`   | string  | Limit result set to products with specified stock status. Options: `instock`, `outofstock` and `onbackorder`.                           |
+| Parameter         | Type    | Description                                                                                                                             |
+|-------------------|---------|-----------------------------------------------------------------------------------------------------------------------------------------|
+| `context`         | string  | Scope under which the request is made; determines fields present in response. Options: `view` and `edit`. Default is `view`.            |
+| `page`            | integer | Current page of the collection. Default is `1`.                                                                                         |
+| `per_page`        | integer | Maximum number of items to be returned in result set. Default is `10`.                                                                  |
+| `search`          | string  | Limit results to those matching a string.                                                                                               |
+| `after`           | string  | Limit response to resources published after a given ISO8601 compliant date.                                                             |
+| `before`          | string  | Limit response to resources published before a given ISO8601 compliant date.                                                            |
+| `modified_after`  | string  | Limit response to resources modified after a given ISO8601 compliant date.                                                              |
+| `modified_before` | string  | Limit response to resources modified after a given ISO8601 compliant date.                                                              |
+| `dates_are_gmt`   | boolean | Whether to consider GMT post dates when limiting response by published or modified date.                                                |
+| `exclude`         | array   | Ensure result set excludes specific IDs.                                                                                                |
+| `include`         | array   | Limit result set to specific ids.                                                                                                       |
+| `offset`          | integer | Offset the result set by a specific number of items.                                                                                    |
+| `order`           | string  | Order sort attribute ascending or descending. Options: `asc` and `desc`. Default is `desc`.                                             |
+| `orderby`         | string  | Sort collection by object attribute. Options: `date`, `id`, `include`, `title`, `slug`, `price`, `popularity` and `rating`. Default is `date`. |
+| `parent`          | array   | Limit result set to those of particular parent IDs.                                                                                     |
+| `parent_exclude`  | array   | Limit result set to all items except those of a particular parent ID.                                                                   |
+| `slug`            | string  | Limit result set to products with a specific slug.                                                                                      |
+| `status`          | string  | Limit result set to products assigned a specific status. Options: `any`, `draft`, `pending`, `private` and `publish`. Default is `any`. |
+| `type`            | string  | Limit result set to products assigned a specific type. Options: `simple`, `grouped`, `external` and `variable`.                         |
+| `sku`             | string  | Limit result set to products with a specific SKU.                                                                                       |
+| `featured`        | boolean | Limit result set to featured products.                                                                                                  |
+| `category`        | string  | Limit result set to products assigned a specific category ID.                                                                           |
+| `tag`             | string  | Limit result set to products assigned a specific tag ID.                                                                                |
+| `shipping_class`  | string  | Limit result set to products assigned a specific shipping class ID.                                                                     |
+| `attribute`       | string  | Limit result set to products with a specific attribute.                                                                                 |
+| `attribute_term`  | string  | Limit result set to products with a specific attribute term ID (required an assigned attribute).                                        |
+| `tax_class`       | string  | Limit result set to products with a specific tax class. Default options: `standard`, `reduced-rate` and `zero-rate`.                    |
+| `on_sale`         | boolean | Limit result set to products on sale.                                                                                                   |
+| `min_price`       | string  | Limit result set to products based on a minimum price.                                                                                  |
+| `max_price`       | string  | Limit result set to products based on a maximum price.                                                                                  |
+| `stock_status`    | string  | Limit result set to products with specified stock status. Options: `instock`, `outofstock` and `onbackorder`.                           |
 
 ## Update a product ##
 


### PR DESCRIPTION
These parameters are added to the endpoints for retrieving products, orders and coupons.

This pull request must be merged when the one that implements these parameters in WooCommerce is released: https://github.com/woocommerce/woocommerce/pull/30585