### PR TITLE
error fix in Python examples and other examples.

### DIFF
--- a/source/includes/wp-api-v3/_shipping-zone-methods.md
+++ b/source/includes/wp-api-v3/_shipping-zone-methods.md
@@ -645,7 +645,7 @@ WooCommerce.put("shipping/zones/5/methods/26", data)
 ```php
 <?php
 $data = [
-    'regular_price' => [
+    'settings' => [
         'cost' => '20.00'
     ]
 ];
@@ -656,7 +656,7 @@ print_r($woocommerce->put('shipping/zones/5/methods/26', $data));
 
 ```python
 data = {
-    "regular_price": {
+    "settings": {
         "cost": "20.00"
     }
 }
@@ -666,7 +666,7 @@ print(wcapi.put("shipping/zones/5/methods/26", data).json())
 
 ```ruby
 data = {
-  regular_price: {
+  settings: {
     "cost": "20.00"
   }
 }


### PR DESCRIPTION
In the examples of some languages the field: "regular_price" is used but it does not work to change the value of the shipping price.
The correct field to use is: "settings" as in the examples in cUrl and Node.js