### PR TITLE
Fixing syntax error

### DIFF
--- a/source/includes/wp-api-v3/_order-refunds.md
+++ b/source/includes/wp-api-v3/_order-refunds.md
@@ -79,7 +79,7 @@ curl -X POST https://example.com/wp-json/wc/v3/orders/723/refunds \
       "refund_total": 10,
       "refund_tax": [
         {
-          "id" "222",
+          "id": "222",
           "refund_total": 20
         }
       ]


### PR DESCRIPTION
Due to the fact that colons are missing there, an error code: rest_invalid_json is thrown out via the API.