### PR TITLE
Fix 403 error when using WooCommerce API (Python)

### DIFF
--- a/source/includes/v2/_introduction.md
+++ b/source/includes/v2/_introduction.md
@@ -456,7 +456,8 @@ wcapi = API(
     url="http://example.com",
     consumer_key="consumer_key",
     consumer_secret="consumer_secret",
-    version="v2"
+    version="v2",
+    user_agent="sample.org", # Your sample user agent
 )
 ```
 

--- a/source/includes/v3/_introduction.md
+++ b/source/includes/v3/_introduction.md
@@ -480,7 +480,8 @@ wcapi = API(
     url="http://example.com", # Your store URL
     consumer_key="consumer_key", # Your consumer key
     consumer_secret="consumer_secret", # Your consumer secret
-    version="v3" # WooCommerce API version
+    version="v3", # WooCommerce API version
+    user_agent="sample.org", # Your sample user agent
 )
 ```
 

--- a/source/includes/wp-api-v1/_authentication.md
+++ b/source/includes/wp-api-v1/_authentication.md
@@ -202,7 +202,8 @@ wcapi = API(
     consumer_key="consumer_key",
     consumer_secret="consumer_secret",
     wp_api=True,
-    version="wc/v1"
+    version="wc/v1",
+    user_agent="sample.org", # Your sample user agent
 )
 ```
 
@@ -269,7 +270,8 @@ wcapi = API(
     consumer_secret="consumer_secret",
     wp_api=True,
     version="wc/v1",
-    query_string_auth=True // Force Basic Authentication as query string true and using under HTTPS
+    user_agent="sample.org", # Your sample user agent
+    query_string_auth=True # Force Basic Authentication as query string true and using under HTTPS
 )
 ```
 

--- a/source/includes/wp-api-v1/_introduction.md
+++ b/source/includes/wp-api-v1/_introduction.md
@@ -227,7 +227,8 @@ wcapi = API(
     consumer_key="consumer_key", # Your consumer key
     consumer_secret="consumer_secret", # Your consumer secret
     wp_api=True, # Enable the WP REST API integration
-    version="wc/v1" # WooCommerce WP REST API version
+    version="wc/v1", # WooCommerce WP REST API version
+    user_agent="sample.org", # Your sample user agent
 )
 ```
 

--- a/source/includes/wp-api-v2/_authentication.md
+++ b/source/includes/wp-api-v2/_authentication.md
@@ -204,7 +204,8 @@ wcapi = API(
     consumer_key="consumer_key",
     consumer_secret="consumer_secret",
     wp_api=True,
-    version="wc/v2"
+    version="wc/v2",
+    user_agent="sample.org", # Your sample user agent
 )
 ```
 
@@ -271,7 +272,8 @@ wcapi = API(
     consumer_secret="consumer_secret",
     wp_api=True,
     version="wc/v2",
-    query_string_auth=True // Force Basic Authentication as query string true and using under HTTPS
+    user_agent="sample.org", # Your sample user agent
+    query_string_auth=True # Force Basic Authentication as query string true and using under HTTPS
 )
 ```
 

--- a/source/includes/wp-api-v2/_introduction.md
+++ b/source/includes/wp-api-v2/_introduction.md
@@ -226,7 +226,8 @@ wcapi = API(
     consumer_key="consumer_key", # Your consumer key
     consumer_secret="consumer_secret", # Your consumer secret
     wp_api=True, # Enable the WP REST API integration
-    version="wc/v2" # WooCommerce WP REST API version
+    version="wc/v2", # WooCommerce WP REST API version
+    user_agent="sample.org", # Your sample user agent
 )
 ```
 

--- a/source/includes/wp-api-v3/_authentication.md
+++ b/source/includes/wp-api-v3/_authentication.md
@@ -206,7 +206,8 @@ wcapi = API(
     consumer_key="consumer_key",
     consumer_secret="consumer_secret",
     wp_api=True,
-    version="wc/v3"
+    version="wc/v3",
+    user_agent="sample.org", # Your sample user agent
 )
 ```
 
@@ -273,7 +274,8 @@ wcapi = API(
     consumer_secret="consumer_secret",
     wp_api=True,
     version="wc/v3",
-    query_string_auth=True // Force Basic Authentication as query string true and using under HTTPS
+    user_agent="sample.org", # Your sample user agent
+    query_string_auth=True, # Force Basic Authentication as query string true and using under HTTPS
 )
 ```
 

--- a/source/includes/wp-api-v3/_introduction.md
+++ b/source/includes/wp-api-v3/_introduction.md
@@ -227,7 +227,8 @@ wcapi = API(
     consumer_key="consumer_key", # Your consumer key
     consumer_secret="consumer_secret", # Your consumer secret
     wp_api=True, # Enable the WP REST API integration
-    version="wc/v3" # WooCommerce WP REST API version
+    version="wc/v3", # WooCommerce WP REST API version
+    user_agent="sample.org", # Your sample user agent
 )
 ```
 


### PR DESCRIPTION
This pull request fixes an issue where a 403 error was returned when trying to use the WooCommerce API in Python. The issue was caused by the lack of a User-Agent header in the API requests.

To fix the issue, a User-Agent header has been added to the API requests, with the value "sample.org" (or anything else).

Changes made:
- Added a User-Agent header to the API requests with the value "sample.org".

Example usage:
```python
from woocommerce import API

wcapi = API(
    url="http://example.com",
    consumer_key="consumer_key",
    consumer_secret="consumer_secret",
    version="v2",
    user_agent="sample.org", # Your sample user agent
)
```