### PR TITLE
Fix ref to webhook delivery ID header.

### DIFF
--- a/source/includes/wp-api-v3/_webhooks.md
+++ b/source/includes/wp-api-v3/_webhooks.md
@@ -35,7 +35,7 @@ Delivery is performed using `wp_remote_post()` (HTTP POST) and processed in the 
 * `X-WC-Webhook-Event` - e.g. `updated`.
 * `X-WC-Webhook-Signature` - a base64 encoded HMAC-SHA256 hash of the payload.
 * `X-WC-Webhook-ID` - webhook's post ID.
-* `X-WC-Delivery-ID` - delivery log ID (a comment).
+* `X-WC-Webhook-Delivery-ID` - delivery log ID (a comment).
 
 The payload is JSON encoded and for API resources (coupons, customers, orders, products), the response is exactly the same as if requested via the REST API.
 


### PR DESCRIPTION
See https://github.com/woocommerce/woocommerce/issues/43400.

Corrects a small oversight: `X-WC-Delivery-ID` should actually be [`X-WC-Webhook-Delivery-ID`](https://github.com/woocommerce/woocommerce/blob/8.6.1/plugins/woocommerce/includes/class-wc-webhook.php#L350).