### PR TITLE
Update REST API docs sidebar.

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -9,10 +9,10 @@ language_tabs:
   - ruby: Ruby
 
 toc_footers:
-  - <a href="https://woocommerce.com/careers/?utm_source=developer+resource+sites&utm_medium=devdocs&utm_campaign=woo+careers&utm_content=core+rest+api+docs" target="_blank">We're hiring!</a>
+  - <a href="https://woo.com/careers/?utm_source=developer+resource+sites&utm_medium=devdocs&utm_campaign=woo+careers&utm_content=core+rest+api+docs" target="_blank">We're hiring!</a>
   - <a href="https://github.com/woocommerce/woocommerce-rest-api-docs">Contributing to WC REST API Docs</a>
-  - <a href="https://github.com/woocommerce/woocommerce-rest-api">REST API Source on GitHub</a>
-  - <a href="https://github.com/woocommerce/woocommerce/issues?labels=API&amp;page=1&amp;state=open">REST API Issues</a>
+  - <a href="https://github.com/woocommerce/woocommerce/tree/trunk/plugins/woocommerce/includes/rest-api">REST API Source on GitHub</a>
+  - <a href="https://github.com/woocommerce/woocommerce/labels/focus%3A%20rest%20api">REST API Issues</a>
   - <a href="https://docs.woocommerce.com/documentation/plugins/woocommerce/">WooCommerce Documentation</a>
   - <a href="https://github.com/woocommerce/woocommerce">WooCommerce Repository</a>
   - <a href="https://github.com/tripit/slate">Documentation Powered by Slate</a>


### PR DESCRIPTION
Small fixes to out-of-date URLs that render in the REST API docs sidebar.

- Woo.com, not WooCommerce.com
- REST API source is now in the mono-repo, not a separate repo.
- REST API issues URL was out-of-date and led to empty results.