### PR TITLE
Updates based on issues in the WooCommerce repo

### DIFF
--- a/source/includes/wp-api-v3/_coupons.md
+++ b/source/includes/wp-api-v3/_coupons.md
@@ -393,7 +393,7 @@ woocommerce.get("coupons").parsed_response
 #### Available parameters ####
 
 | Parameter         | Type    | Description                                                                                                                  |
-| ----------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| ----------------- | ------- |------------------------------------------------------------------------------------------------------------------------------|
 | `context`         | string  | Scope under which the request is made; determines fields present in response. Options: `view` and `edit`. Default is `view`. |
 | `page`            | integer | Current page of the collection. Default is `1`.                                                                              |
 | `per_page`        | integer | Maximum number of items to be returned in result set. Default is `10`.                                                       |
@@ -407,7 +407,7 @@ woocommerce.get("coupons").parsed_response
 | `include`         | array   | Limit result set to specific ids.                                                                                            |
 | `offset`          | integer | Offset the result set by a specific number of items.                                                                         |
 | `order`           | string  | Order sort attribute ascending or descending. Options: `asc` and `desc`. Default is `desc`.                                  |
-| `orderby`         | string  | Sort collection by object attribute. Options: `date`, `id`, `include`, `title` and `slug`. Default is `date`.                |
+| `orderby`         | string  | Sort collection by object attribute. Options: `date`, `modified`, `id`, `include`, `title` and `slug`. Default is `date`.    |
 | `code`            | string  | Limit result set to resources with a specific code.                                                                          |
 
 ## Update a coupon ##

--- a/source/includes/wp-api-v3/_order-refunds.md
+++ b/source/includes/wp-api-v3/_order-refunds.md
@@ -64,7 +64,7 @@ The order refunds API allows you to create, view, and delete individual refunds,
 | `rate_code`          | string  | Tax rate code. <i class="label label-info">read-only</i>                                 |
 | `rate_id`            | integer | Tax rate ID. <i class="label label-info">read-only</i>                                   |
 | `label`              | string  | Tax rate label. <i class="label label-info">read-only</i>                                |
-| `compound`           | boolean | Show if is a compound tax rate. <i class="label label-info">read-only</i>                |
+| `compound`           | boolean | Whether or not this is a compound tax rate. <i class="label label-info">read-only</i>              |
 | `tax_total`          | string  | Tax total (not including shipping taxes). <i class="label label-info">read-only</i>      |
 | `shipping_tax_total` | string  | Shipping tax total. <i class="label label-info">read-only</i>                            |
 | `meta_data`          | array   | Meta data. See [Order refund - Meta data properties](#order-refund-meta-data-properties) |

--- a/source/includes/wp-api-v3/_order-refunds.md
+++ b/source/includes/wp-api-v3/_order-refunds.md
@@ -47,7 +47,6 @@ The order refunds API allows you to create, view, and delete individual refunds,
 | `meta_data`    | array   | Meta data. See [Order refund - Meta data properties](#order-refund-meta-data-properties)                                                        |
 | `sku`          | string  | Product SKU. <i class="label label-info">read-only</i>                                                                                          |
 | `price`        | string  | Product price. <i class="label label-info">read-only</i>                                                                                        |
-| `refund_total` | number  | The amount to refund for this line item, excluding taxes. <i class="label label-info">write-only</i>                                            |
 
 #### Order refund line item - Taxes properties ####
 
@@ -56,7 +55,6 @@ The order refunds API allows you to create, view, and delete individual refunds,
 | `id`           | integer | Tax rate ID. <i class="label label-info">read-only</i>                         |
 | `total`        | string  | Tax total. <i class="label label-info">read-only</i>                           |
 | `subtotal`     | string  | Tax subtotal. <i class="label label-info">read-only</i>                        |
-| `refund_total` | number  | The amount to refund for this tax. <i class="label label-info">write-only</i>  |
 
 ### Order refund - Tax lines properties ###
 
@@ -249,6 +247,21 @@ woocommerce.post("orders/723/refunds", data).parsed_response
   }
 }
 ```
+
+#### Line item parameters ####
+
+| Parameter      | Type    | Description                                                                |
+|----------------|---------|----------------------------------------------------------------------------|
+| `id`           | integer | The ID of the line item in the order.                                      |
+| `refund_total` | number  | The amount to refund for this line item, excluding taxes.                  |
+| `refund_tax`   | array   | Refunds for tax rates. See [Refund tax parameters](#refund-tax-parameters) |
+
+#### Refund tax parameters ####
+
+| Parameter      | Type    | Description                                                    |
+|----------------|---------|----------------------------------------------------------------|
+| `id`           | integer | The ID of the tax rate.                                        |
+| `refund_total` | number  | The amount of tax to refund for this line item. |
 
 ## Retrieve a refund ##
 

--- a/source/includes/wp-api-v3/_order-refunds.md
+++ b/source/includes/wp-api-v3/_order-refunds.md
@@ -484,7 +484,7 @@ woocommerce.get("orders/723/refunds").parsed_response
 | `include`        | array   | Limit result set to specific ids.                                                                                            |
 | `offset`         | integer | Offset the result set by a specific number of items.                                                                         |
 | `order`          | string  | Order sort attribute ascending or descending. Options: `asc` and `desc`. Default is `desc`.                                  |
-| `orderby`        | string  | Sort collection by object attribute. Options: `date`, `id`, `include`, `title` and `slug`. Default is `date`.                |
+| `orderby`        | string  | Sort collection by object attribute. Options: `date`, `modified`, `id`, `include`, `title` and `slug`. Default is `date`.    |
 | `parent`         | array   | Limit result set to those of particular parent IDs.                                                                          |
 | `parent_exclude` | array   | Limit result set to all items except those of a particular parent ID.                                                        |
 | `dp`             | integer | Number of decimal points to use in each resource. Default is `2`.                                                            |

--- a/source/includes/wp-api-v3/_order-refunds.md
+++ b/source/includes/wp-api-v3/_order-refunds.md
@@ -1,22 +1,25 @@
-# Refunds #
+# Order refunds #
 
-The refunds API allows you to create, view, and delete individual refunds.
+The order refunds API allows you to create, view, and delete individual refunds, based on an existing order.
 
 ## Order refund properties ##
 
-| Attribute          | Type      | Description                                                                                                                                      |
-|--------------------|-----------|--------------------------------------------------------------------------------------------------------------------------------------------------|
-| `id`               | integer   | Unique identifier for the resource. <i class="label label-info">read-only</i>                                                                    |
-| `date_created`     | date-time | The date the order refund was created, in the site's timezone. <i class="label label-info">read-only</i>                                         |
-| `date_created_gmt` | date-time | The date the order refund was created, as GMT. <i class="label label-info">read-only</i>                                                         |
+| Attribute          | Type      | Description                                                                                                                                                                   |
+|--------------------|-----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `id`               | integer   | Unique identifier for the resource. <i class="label label-info">read-only</i>                                                                                                 |
+| `date_created`     | date-time | The date the order refund was created, in the site's timezone. <i class="label label-info">read-only</i>                                                                      |
+| `date_created_gmt` | date-time | The date the order refund was created, as GMT. <i class="label label-info">read-only</i>                                                                                      |
 | `amount`           | string    | Total refund amount. Optional. If this parameter is provided, it will take precedence over line item totals, even when total of line items does not matches with this amount. |
-| `reason`           | string    | Reason for refund.                                                                                                                               |
-| `refunded_by`      | integer   | User ID of user who created the refund.                                                                                                          |
-| `refunded_payment` | boolean   | If the payment was refunded via the API. See `api_refund`. <i class="label label-info">read-only</i>                                             |
-| `meta_data`        | array     | Meta data. See [Order refund - Meta data properties](#order-refund-meta-data-properties)                                                         |
-| `line_items`       | array     | Line items data. See [Order refund - Line items properties](#order-refund-line-items-properties)                                                 |
-| `api_refund`       | boolean   | When true, the payment gateway API is used to generate the refund. Default is `true`. <i class="label label-info">write-only</i>                 |
-| `api_restock`       | boolean   | When true, the selected line items are restocked Default is `true`. <i class="label label-info">write-only</i>                 |
+| `reason`           | string    | Reason for refund.                                                                                                                                                            |
+| `refunded_by`      | integer   | User ID of user who created the refund.                                                                                                                                       |
+| `refunded_payment` | boolean   | If the payment was refunded via the API. See `api_refund`. <i class="label label-info">read-only</i>                                                                          |
+| `meta_data`        | array     | Meta data. See [Order refund - Meta data properties](#order-refund-meta-data-properties)                                                                                      |
+| `line_items`       | array     | Line items data. See [Order refund - Line items properties](#order-refund-line-items-properties)                                                                              |
+| `tax_lines`        | array     | Tax lines data. See [Order refund - Tax lines properties](#order-refund-tax-lines-properties) <i class="label label-info">read-only</i>                                       |
+| `shipping_lines`   | array     | Shipping lines data. See [Order refund - Shipping lines properties](#order-refund-shipping-lines-properties)                                                                  |
+| `fee_lines`        | array     | Fee lines data. See [Order refund - Fee lines properties](#order-refund-fee-lines-properties)                                                                                 |
+| `api_refund`       | boolean   | When true, the payment gateway API is used to generate the refund. Default is `true`. <i class="label label-info">write-only</i>                                              |
+| `api_restock`      | boolean   | When true, the selected line items are restocked Default is `true`. <i class="label label-info">write-only</i>                                                                |
 
 ### Order refund - Meta data properties ###
 
@@ -54,6 +57,44 @@ The refunds API allows you to create, view, and delete individual refunds.
 | `total`        | string  | Tax total. <i class="label label-info">read-only</i>                           |
 | `subtotal`     | string  | Tax subtotal. <i class="label label-info">read-only</i>                        |
 | `refund_total` | number  | The amount to refund for this tax. <i class="label label-info">write-only</i>  |
+
+### Order refund - Tax lines properties ###
+
+| Attribute            | Type    | Description                                                                              |
+|----------------------|---------|------------------------------------------------------------------------------------------|
+| `id`                 | integer | Item ID. <i class="label label-info">read-only</i>                                       |
+| `rate_code`          | string  | Tax rate code. <i class="label label-info">read-only</i>                                 |
+| `rate_id`            | string  | Tax rate ID. <i class="label label-info">read-only</i>                                   |
+| `label`              | string  | Tax rate label. <i class="label label-info">read-only</i>                                |
+| `compound`           | boolean | Show if is a compound tax rate. <i class="label label-info">read-only</i>                |
+| `tax_total`          | string  | Tax total (not including shipping taxes). <i class="label label-info">read-only</i>      |
+| `shipping_tax_total` | string  | Shipping tax total. <i class="label label-info">read-only</i>                            |
+| `meta_data`          | array   | Meta data. See [Order refund - Meta data properties](#order-refund-meta-data-properties) |
+
+### Order refund - Shipping lines properties ###
+
+| Attribute      | Type    | Description                                                                                                                         |
+|----------------|---------|-------------------------------------------------------------------------------------------------------------------------------------|
+| `id`           | integer | Item ID. <i class="label label-info">read-only</i>                                                                                  |
+| `method_title` | string  | Shipping method name.                                                                                                               |
+| `method_id`    | string  | Shipping method ID.                                                                                                                 |
+| `total`        | string  | Line total (after discounts).                                                                                                       |
+| `total_tax`    | string  | Line total tax (after discounts). <i class="label label-info">read-only</i>                                                         |
+| `taxes`        | array   | Line taxes. See [Order refund - Tax lines properties](#order-refund-tax-lines-properties) <i class="label label-info">read-only</i> |
+| `meta_data`    | array   | Meta data. See [Order refund - Meta data properties](#order-refund-meta-data-properties)                                            |
+
+### Order refund - Fee lines properties ###
+
+| Attribute    | Type    | Description                                                                                                                         |
+|--------------|---------|-------------------------------------------------------------------------------------------------------------------------------------|
+| `id`         | integer | Item ID. <i class="label label-info">read-only</i>                                                                                  |
+| `name`       | string  | Fee name.                                                                                                                           |
+| `tax_class`  | string  | Tax class of fee.                                                                                                                   |
+| `tax_status` | string  | Tax status of fee. Options: `taxable` and `none`.                                                                                   |
+| `total`      | string  | Line total (after discounts).                                                                                                       |
+| `total_tax`  | string  | Line total tax (after discounts). <i class="label label-info">read-only</i>                                                         |
+| `taxes`      | array   | Line taxes. See [Order refund - Tax lines properties](#order-refund-tax-lines-properties) <i class="label label-info">read-only</i> |
+| `meta_data`  | array   | Meta data. See [Order refund - Meta data properties](#order-refund-meta-data-properties)                                            |
 
 ## Create a refund ##
 

--- a/source/includes/wp-api-v3/_order-refunds.md
+++ b/source/includes/wp-api-v3/_order-refunds.md
@@ -64,7 +64,7 @@ The order refunds API allows you to create, view, and delete individual refunds,
 |----------------------|---------|------------------------------------------------------------------------------------------|
 | `id`                 | integer | Item ID. <i class="label label-info">read-only</i>                                       |
 | `rate_code`          | string  | Tax rate code. <i class="label label-info">read-only</i>                                 |
-| `rate_id`            | string  | Tax rate ID. <i class="label label-info">read-only</i>                                   |
+| `rate_id`            | integer | Tax rate ID. <i class="label label-info">read-only</i>                                   |
 | `label`              | string  | Tax rate label. <i class="label label-info">read-only</i>                                |
 | `compound`           | boolean | Show if is a compound tax rate. <i class="label label-info">read-only</i>                |
 | `tax_total`          | string  | Tax total (not including shipping taxes). <i class="label label-info">read-only</i>      |

--- a/source/includes/wp-api-v3/_order-refunds.md
+++ b/source/includes/wp-api-v3/_order-refunds.md
@@ -38,7 +38,7 @@ The order refunds API allows you to create, view, and delete individual refunds,
 | `product_id`   | integer | Product ID.                                                                                                                                     |
 | `variation_id` | integer | Variation ID, if applicable.                                                                                                                    |
 | `quantity`     | integer | Quantity ordered.                                                                                                                               |
-| `tax_class`    | integer | Tax class of product.                                                                                                                           |
+| `tax_class`    | string  | Tax class of product.                                                                                                                           |
 | `subtotal`     | string  | Line subtotal (before discounts).                                                                                                               |
 | `subtotal_tax` | string  | Line subtotal tax (before discounts). <i class="label label-info">read-only</i>                                                                 |
 | `total`        | string  | Line total (after discounts).                                                                                                                   |

--- a/source/includes/wp-api-v3/_order-refunds.md
+++ b/source/includes/wp-api-v3/_order-refunds.md
@@ -333,6 +333,8 @@ woocommerce.get("orders/723/refunds/726").parsed_response
 
 This API helps you to view all the refunds from an order.
 
+Note: To view a list of refunds from your store, regardless of order, check out the [refunds endpoint](#refunds).
+
 ### HTTP request ###
 
 <div class="api-endpoint">

--- a/source/includes/wp-api-v3/_orders.md
+++ b/source/includes/wp-api-v3/_orders.md
@@ -1174,28 +1174,28 @@ woocommerce.get("orders").parsed_response
 
 #### Available parameters ####
 
-| Parameter         | Type    | Description                                                                                                                              |
-|-------------------|---------|------------------------------------------------------------------------------------------------------------------------------------------|
-| `context`         | string  | Scope under which the request is made; determines fields present in response. Options: `view` and `edit`. Default is `view`.             |
-| `page`            | integer | Current page of the collection. Default is `1`.                                                                                          |
-| `per_page`        | integer | Maximum number of items to be returned in result set. Default is `10`.                                                                   |
-| `search`          | string  | Limit results to those matching a string.                                                                                                |
-| `after`           | string  | Limit response to resources published after a given ISO8601 compliant date.                                                              |
-| `before`          | string  | Limit response to resources published before a given ISO8601 compliant date.                                                             |
-| `modified_after`  | string  | Limit response to resources modified after a given ISO8601 compliant date.                                                               |
-| `modified_before` | string  | Limit response to resources modified after a given ISO8601 compliant date.                                                               |
-| `dates_are_gmt`   | boolean | Whether to consider GMT post dates when limiting response by published or modified date.                                                 |
-| `exclude`         | array   | Ensure result set excludes specific IDs.                                                                                                 |
-| `include`         | array   | Limit result set to specific ids.                                                                                                        |
-| `offset`          | integer | Offset the result set by a specific number of items.                                                                                     |
-| `order`           | string  | Order sort attribute ascending or descending. Options: `asc` and `desc`. Default is `desc`.                                              |
-| `orderby`         | string  | Sort collection by object attribute. Options: `date`, `id`, `include`, `title` and `slug`. Default is `date`.                            |
-| `parent`          | array   | Limit result set to those of particular parent IDs.                                                                                      |
-| `parent_exclude`  | array   | Limit result set to all items except those of a particular parent ID.                                                                    |
+| Parameter         | Type    | Description                                                                                                                                                                              |
+|-------------------|---------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `context`         | string  | Scope under which the request is made; determines fields present in response. Options: `view` and `edit`. Default is `view`.                                                             |
+| `page`            | integer | Current page of the collection. Default is `1`.                                                                                                                                          |
+| `per_page`        | integer | Maximum number of items to be returned in result set. Default is `10`.                                                                                                                   |
+| `search`          | string  | Limit results to those matching a string.                                                                                                                                                |
+| `after`           | string  | Limit response to resources published after a given ISO8601 compliant date.                                                                                                              |
+| `before`          | string  | Limit response to resources published before a given ISO8601 compliant date.                                                                                                             |
+| `modified_after`  | string  | Limit response to resources modified after a given ISO8601 compliant date.                                                                                                               |
+| `modified_before` | string  | Limit response to resources modified after a given ISO8601 compliant date.                                                                                                               |
+| `dates_are_gmt`   | boolean | Whether to consider GMT post dates when limiting response by published or modified date.                                                                                                 |
+| `exclude`         | array   | Ensure result set excludes specific IDs.                                                                                                                                                 |
+| `include`         | array   | Limit result set to specific ids.                                                                                                                                                        |
+| `offset`          | integer | Offset the result set by a specific number of items.                                                                                                                                     |
+| `order`           | string  | Order sort attribute ascending or descending. Options: `asc` and `desc`. Default is `desc`.                                                                                              |
+| `orderby`         | string  | Sort collection by object attribute. Options: `date`, `modified`, `id`, `include`, `title` and `slug`. Default is `date`.                                                                |
+| `parent`          | array   | Limit result set to those of particular parent IDs.                                                                                                                                      |
+| `parent_exclude`  | array   | Limit result set to all items except those of a particular parent ID.                                                                                                                    |
 | `status`          | array   | Limit result set to orders assigned a specific status. Options: `any`, `pending`, `processing`, `on-hold`, `completed`, `cancelled`, `refunded`, `failed` and `trash`. Default is `any`. |
-| `customer`        | integer | Limit result set to orders assigned a specific customer.                                                                                 |
-| `product`         | integer | Limit result set to orders assigned a specific product.                                                                                  |
-| `dp`              | integer | Number of decimal points to use in each resource. Default is `2`.                                                                        |
+| `customer`        | integer | Limit result set to orders assigned a specific customer.                                                                                                                                 |
+| `product`         | integer | Limit result set to orders assigned a specific product.                                                                                                                                  |
+| `dp`              | integer | Number of decimal points to use in each resource. Default is `2`.                                                                                                                        |
 
 ## Update an Order ##
 

--- a/source/includes/wp-api-v3/_orders.md
+++ b/source/includes/wp-api-v3/_orders.md
@@ -112,7 +112,7 @@ The orders API allows you to create, view, update, and delete individual, or a b
 |----------------------|---------|-------------------------------------------------------------------------------------|
 | `id`                 | integer | Item ID. <i class="label label-info">read-only</i>                                  |
 | `rate_code`          | string  | Tax rate code. <i class="label label-info">read-only</i>                            |
-| `rate_id`            | string  | Tax rate ID. <i class="label label-info">read-only</i>                              |
+| `rate_id`            | integer | Tax rate ID. <i class="label label-info">read-only</i>                              |
 | `label`              | string  | Tax rate label. <i class="label label-info">read-only</i>                           |
 | `compound`           | boolean | Show if is a compound tax rate. <i class="label label-info">read-only</i>           |
 | `tax_total`          | string  | Tax total (not including shipping taxes). <i class="label label-info">read-only</i> |

--- a/source/includes/wp-api-v3/_orders.md
+++ b/source/includes/wp-api-v3/_orders.md
@@ -89,22 +89,22 @@ The orders API allows you to create, view, update, and delete individual, or a b
 
 ### Order - Line items properties ###
 
-| Attribute      | Type    | Description                                                                                                   |
-|----------------|---------|---------------------------------------------------------------------------------------------------------------|
-| `id`           | integer | Item ID. <i class="label label-info">read-only</i>                                                            |
-| `name`         | string  | Product name.                                                                                                 |
-| `product_id`   | integer | Product ID.                                                                                                   |
-| `variation_id` | integer | Variation ID, if applicable.                                                                                  |
-| `quantity`     | integer | Quantity ordered.                                                                                             |
-| `tax_class`    | string | Slug of the tax class of product.                                                                                         |
-| `subtotal`     | string  | Line subtotal (before discounts).                                                                             |
-| `subtotal_tax` | string  | Line subtotal tax (before discounts). <i class="label label-info">read-only</i>                               |
-| `total`        | string  | Line total (after discounts).                                                                                 |
-| `total_tax`    | string  | Line total tax (after discounts). <i class="label label-info">read-only</i>                                   |
-| `taxes`        | array   | Line taxes. See [Order - Taxes properties](#order-taxes-properties) <i class="label label-info">read-only</i> |
-| `meta_data`    | array   | Meta data. See [Order - Meta data properties](#order-meta-data-properties)                                    |
-| `sku`          | string  | Product SKU. <i class="label label-info">read-only</i>                                                        |
-| `price`        | string  | Product price. <i class="label label-info">read-only</i>                                                      |
+| Attribute      | Type    | Description                                                                                                           |
+|----------------|---------|-----------------------------------------------------------------------------------------------------------------------|
+| `id`           | integer | Item ID. <i class="label label-info">read-only</i>                                                                    |
+| `name`         | string  | Product name.                                                                                                         |
+| `product_id`   | integer | Product ID.                                                                                                           |
+| `variation_id` | integer | Variation ID, if applicable.                                                                                          |
+| `quantity`     | integer | Quantity ordered.                                                                                                     |
+| `tax_class`    | string | Slug of the tax class of product.                                                                                     |
+| `subtotal`     | string  | Line subtotal (before discounts).                                                                                     |
+| `subtotal_tax` | string  | Line subtotal tax (before discounts). <i class="label label-info">read-only</i>                                       |
+| `total`        | string  | Line total (after discounts).                                                                                         |
+| `total_tax`    | string  | Line total tax (after discounts). <i class="label label-info">read-only</i>                                           |
+| `taxes`        | array   | Line taxes. See [Order - Tax lines properties](#order-tax-lines-properties) <i class="label label-info">read-only</i> |
+| `meta_data`    | array   | Meta data. See [Order - Meta data properties](#order-meta-data-properties)                                            |
+| `sku`          | string  | Product SKU. <i class="label label-info">read-only</i>                                                                |
+| `price`        | string  | Product price. <i class="label label-info">read-only</i>                                                              |
 
 ### Order - Tax lines properties ###
 
@@ -121,28 +121,28 @@ The orders API allows you to create, view, update, and delete individual, or a b
 
 ### Order - Shipping lines properties ###
 
-| Attribute      | Type    | Description                                                                                                   |
-|----------------|---------|---------------------------------------------------------------------------------------------------------------|
-| `id`           | integer | Item ID. <i class="label label-info">read-only</i>                                                            |
-| `method_title` | string  | Shipping method name.                                                                                         |
-| `method_id`    | string  | Shipping method ID.                                                                                           |
-| `total`        | string  | Line total (after discounts).                                                                                 |
-| `total_tax`    | string  | Line total tax (after discounts). <i class="label label-info">read-only</i>                                   |
-| `taxes`        | array   | Line taxes. See [Order - Taxes properties](#order-taxes-properties) <i class="label label-info">read-only</i> |
-| `meta_data`    | array   | Meta data. See [Order - Meta data properties](#order-meta-data-properties)                                    |
+| Attribute      | Type    | Description                                                                                                           |
+|----------------|---------|-----------------------------------------------------------------------------------------------------------------------|
+| `id`           | integer | Item ID. <i class="label label-info">read-only</i>                                                                    |
+| `method_title` | string  | Shipping method name.                                                                                                 |
+| `method_id`    | string  | Shipping method ID.                                                                                                   |
+| `total`        | string  | Line total (after discounts).                                                                                         |
+| `total_tax`    | string  | Line total tax (after discounts). <i class="label label-info">read-only</i>                                           |
+| `taxes`        | array   | Line taxes. See [Order - Tax lines properties](#order-tax-lines-properties) <i class="label label-info">read-only</i> |
+| `meta_data`    | array   | Meta data. See [Order - Meta data properties](#order-meta-data-properties)                                            |
 
 ### Order - Fee lines properties ###
 
-| Attribute    | Type    | Description                                                                                                   |
-|--------------|---------|---------------------------------------------------------------------------------------------------------------|
-| `id`         | integer | Item ID. <i class="label label-info">read-only</i>                                                            |
-| `name`       | string  | Fee name.                                                                                                     |
-| `tax_class`  | string  | Tax class of fee.                                                                                             |
-| `tax_status` | string  | Tax status of fee. Options: `taxable` and `none`.                                                             |
-| `total`      | string  | Line total (after discounts).                                                                                 |
-| `total_tax`  | string  | Line total tax (after discounts). <i class="label label-info">read-only</i>                                   |
-| `taxes`      | array   | Line taxes. See [Order - Taxes properties](#order-taxes-properties) <i class="label label-info">read-only</i> |
-| `meta_data`  | array   | Meta data. See [Order - Meta data properties](#order-meta-data-properties)                                    |
+| Attribute    | Type    | Description                                                                                                           |
+|--------------|---------|-----------------------------------------------------------------------------------------------------------------------|
+| `id`         | integer | Item ID. <i class="label label-info">read-only</i>                                                                    |
+| `name`       | string  | Fee name.                                                                                                             |
+| `tax_class`  | string  | Tax class of fee.                                                                                                     |
+| `tax_status` | string  | Tax status of fee. Options: `taxable` and `none`.                                                                     |
+| `total`      | string  | Line total (after discounts).                                                                                         |
+| `total_tax`  | string  | Line total tax (after discounts). <i class="label label-info">read-only</i>                                           |
+| `taxes`      | array   | Line taxes. See [Order - Tax lines properties](#order-tax-lines-properties) <i class="label label-info">read-only</i> |
+| `meta_data`  | array   | Meta data. See [Order - Meta data properties](#order-meta-data-properties)                                            |
 
 ### Order - Coupon lines properties ###
 
@@ -161,19 +161,6 @@ The orders API allows you to create, view, update, and delete individual, or a b
 | `id`      | integer | Refund ID. <i class="label label-info">read-only</i>     |
 | `reason`  | string  | Refund reason. <i class="label label-info">read-only</i> |
 | `total`   | string  | Refund total. <i class="label label-info">read-only</i>  |
-
-### Order - Taxes properties ###
-
-| Attribute            | Type    | Description                                                                         |
-|----------------------|---------|-------------------------------------------------------------------------------------|
-| `id`                 | integer | Item ID. <i class="label label-info">read-only</i>                                  |
-| `rate_code`          | string  | Tax rate code. <i class="label label-info">read-only</i>                            |
-| `rate_id`            | string  | Tax rate ID. <i class="label label-info">read-only</i>                              |
-| `label`              | string  | Tax rate label. <i class="label label-info">read-only</i>                           |
-| `compound`           | boolean | Show if is a compound tax rate. <i class="label label-info">read-only</i>           |
-| `tax_total`          | string  | Tax total (not including shipping taxes). <i class="label label-info">read-only</i> |
-| `shipping_tax_total` | string  | Shipping tax total. <i class="label label-info">read-only</i>                       |
-| `meta_data`          | array   | Meta data. See [Order - Meta data properties](#order-meta-data-properties)          |
 
 ## Create an order ##
 

--- a/source/includes/wp-api-v3/_orders.md
+++ b/source/includes/wp-api-v3/_orders.md
@@ -114,7 +114,7 @@ The orders API allows you to create, view, update, and delete individual, or a b
 | `rate_code`          | string  | Tax rate code. <i class="label label-info">read-only</i>                            |
 | `rate_id`            | integer | Tax rate ID. <i class="label label-info">read-only</i>                              |
 | `label`              | string  | Tax rate label. <i class="label label-info">read-only</i>                           |
-| `compound`           | boolean | Show if is a compound tax rate. <i class="label label-info">read-only</i>           |
+| `compound`           | boolean | Whether or not this is a compound tax rate. <i class="label label-info">read-only</i>           |
 | `tax_total`          | string  | Tax total (not including shipping taxes). <i class="label label-info">read-only</i> |
 | `shipping_tax_total` | string  | Shipping tax total. <i class="label label-info">read-only</i>                       |
 | `meta_data`          | array   | Meta data. See [Order - Meta data properties](#order-meta-data-properties)          |

--- a/source/includes/wp-api-v3/_product-variations.md
+++ b/source/includes/wp-api-v3/_product-variations.md
@@ -619,7 +619,7 @@ woocommerce.get("products/22/variations").parsed_response
 | `include`        | array   | Limit result set to specific ids.                                                                                                       |
 | `offset`         | integer | Offset the result set by a specific number of items.                                                                                    |
 | `order`          | string  | Order sort attribute ascending or descending. Options: `asc` and `desc`. Default is `desc`.                                             |
-| `orderby`        | string  | Sort collection by object attribute. Options: `date`, `id`, `include`, `title` and `slug`. Default is `date`.                           |
+| `orderby`        | string  | Sort collection by object attribute. Options: `date`, `modified`, `id`, `include`, `title` and `slug`. Default is `date`.                          |
 | `parent`         | array   | Limit result set to those of particular parent IDs.                                                                                     |
 | `parent_exclude` | array   | Limit result set to all items except those of a particular parent ID.                                                                   |
 | `slug`           | string  | Limit result set to products with a specific slug.                                                                                      |

--- a/source/includes/wp-api-v3/_products.md
+++ b/source/includes/wp-api-v3/_products.md
@@ -1461,39 +1461,39 @@ woocommerce.get("products").parsed_response
 
 #### Available parameters ####
 
-| Parameter         | Type    | Description                                                                                                                             |
-|-------------------|---------|-----------------------------------------------------------------------------------------------------------------------------------------|
-| `context`         | string  | Scope under which the request is made; determines fields present in response. Options: `view` and `edit`. Default is `view`.            |
-| `page`            | integer | Current page of the collection. Default is `1`.                                                                                         |
-| `per_page`        | integer | Maximum number of items to be returned in result set. Default is `10`.                                                                  |
-| `search`          | string  | Limit results to those matching a string.                                                                                               |
-| `after`           | string  | Limit response to resources published after a given ISO8601 compliant date.                                                             |
-| `before`          | string  | Limit response to resources published before a given ISO8601 compliant date.                                                            |
-| `modified_after`  | string  | Limit response to resources modified after a given ISO8601 compliant date.                                                              |
-| `modified_before` | string  | Limit response to resources modified after a given ISO8601 compliant date.                                                              |
-| `dates_are_gmt`   | boolean | Whether to consider GMT post dates when limiting response by published or modified date.                                                |
-| `exclude`         | array   | Ensure result set excludes specific IDs.                                                                                                |
-| `include`         | array   | Limit result set to specific ids.                                                                                                       |
-| `offset`          | integer | Offset the result set by a specific number of items.                                                                                    |
-| `order`           | string  | Order sort attribute ascending or descending. Options: `asc` and `desc`. Default is `desc`.                                             |
-| `orderby`         | string  | Sort collection by object attribute. Options: `date`, `id`, `include`, `title`, `slug`, `price`, `popularity` and `rating`. Default is `date`. |
-| `parent`          | array   | Limit result set to those of particular parent IDs.                                                                                     |
-| `parent_exclude`  | array   | Limit result set to all items except those of a particular parent ID.                                                                   |
-| `slug`            | string  | Limit result set to products with a specific slug.                                                                                      |
-| `status`          | string  | Limit result set to products assigned a specific status. Options: `any`, `draft`, `pending`, `private` and `publish`. Default is `any`. |
-| `type`            | string  | Limit result set to products assigned a specific type. Options: `simple`, `grouped`, `external` and `variable`.                         |
-| `sku`             | string  | Limit result set to products with a specific SKU.                                                                                       |
-| `featured`        | boolean | Limit result set to featured products.                                                                                                  |
-| `category`        | string  | Limit result set to products assigned a specific category ID.                                                                           |
-| `tag`             | string  | Limit result set to products assigned a specific tag ID.                                                                                |
-| `shipping_class`  | string  | Limit result set to products assigned a specific shipping class ID.                                                                     |
-| `attribute`       | string  | Limit result set to products with a specific attribute.                                                                                 |
-| `attribute_term`  | string  | Limit result set to products with a specific attribute term ID (required an assigned attribute).                                        |
-| `tax_class`       | string  | Limit result set to products with a specific tax class. Default options: `standard`, `reduced-rate` and `zero-rate`.                    |
-| `on_sale`         | boolean | Limit result set to products on sale.                                                                                                   |
-| `min_price`       | string  | Limit result set to products based on a minimum price.                                                                                  |
-| `max_price`       | string  | Limit result set to products based on a maximum price.                                                                                  |
-| `stock_status`    | string  | Limit result set to products with specified stock status. Options: `instock`, `outofstock` and `onbackorder`.                           |
+| Parameter         | Type    | Description                                                                                                                                                               |
+|-------------------|---------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `context`         | string  | Scope under which the request is made; determines fields present in response. Options: `view` and `edit`. Default is `view`.                                              |
+| `page`            | integer | Current page of the collection. Default is `1`.                                                                                                                           |
+| `per_page`        | integer | Maximum number of items to be returned in result set. Default is `10`.                                                                                                    |
+| `search`          | string  | Limit results to those matching a string.                                                                                                                                 |
+| `after`           | string  | Limit response to resources published after a given ISO8601 compliant date.                                                                                               |
+| `before`          | string  | Limit response to resources published before a given ISO8601 compliant date.                                                                                              |
+| `modified_after`  | string  | Limit response to resources modified after a given ISO8601 compliant date.                                                                                                |
+| `modified_before` | string  | Limit response to resources modified after a given ISO8601 compliant date.                                                                                                |
+| `dates_are_gmt`   | boolean | Whether to consider GMT post dates when limiting response by published or modified date.                                                                                  |
+| `exclude`         | array   | Ensure result set excludes specific IDs.                                                                                                                                  |
+| `include`         | array   | Limit result set to specific ids.                                                                                                                                         |
+| `offset`          | integer | Offset the result set by a specific number of items.                                                                                                                      |
+| `order`           | string  | Order sort attribute ascending or descending. Options: `asc` and `desc`. Default is `desc`.                                                                               |
+| `orderby`         | string  | Sort collection by object attribute. Options: `date`, `modified`, `id`, `include`, `title`, `slug`, `price`, `popularity`, `rating`, and `menu_order`. Default is `date`. |
+| `parent`          | array   | Limit result set to those of particular parent IDs.                                                                                                                       |
+| `parent_exclude`  | array   | Limit result set to all items except those of a particular parent ID.                                                                                                     |
+| `slug`            | string  | Limit result set to products with a specific slug.                                                                                                                        |
+| `status`          | string  | Limit result set to products assigned a specific status. Options: `any`, `draft`, `pending`, `private` and `publish`. Default is `any`.                                   |
+| `type`            | string  | Limit result set to products assigned a specific type. Options: `simple`, `grouped`, `external` and `variable`.                                                           |
+| `sku`             | string  | Limit result set to products with a specific SKU.                                                                                                                         |
+| `featured`        | boolean | Limit result set to featured products.                                                                                                                                    |
+| `category`        | string  | Limit result set to products assigned a specific category ID.                                                                                                             |
+| `tag`             | string  | Limit result set to products assigned a specific tag ID.                                                                                                                  |
+| `shipping_class`  | string  | Limit result set to products assigned a specific shipping class ID.                                                                                                       |
+| `attribute`       | string  | Limit result set to products with a specific attribute.                                                                                                                   |
+| `attribute_term`  | string  | Limit result set to products with a specific attribute term ID (required an assigned attribute).                                                                          |
+| `tax_class`       | string  | Limit result set to products with a specific tax class. Default options: `standard`, `reduced-rate` and `zero-rate`.                                                      |
+| `on_sale`         | boolean | Limit result set to products on sale.                                                                                                                                     |
+| `min_price`       | string  | Limit result set to products based on a minimum price.                                                                                                                    |
+| `max_price`       | string  | Limit result set to products based on a maximum price.                                                                                                                    |
+| `stock_status`    | string  | Limit result set to products with specified stock status. Options: `instock`, `outofstock` and `onbackorder`.                                                             |
 
 ## Update a product ##
 

--- a/source/includes/wp-api-v3/_products.md
+++ b/source/includes/wp-api-v3/_products.md
@@ -108,7 +108,7 @@ The products API allows you to create, view, update, and delete individual, or a
 
 | Attribute           | Type      | Description                                                                                             |
 |---------------------|-----------|---------------------------------------------------------------------------------------------------------|
-| `id`                | integer   | Image ID.                                                                                               |
+| `id`                | integer   | The attachment ID from the Media Library.                                                               |
 | `date_created`      | date-time | The date the image was created, in the site's timezone. <i class="label label-info">read-only</i>       |
 | `date_created_gmt`  | date-time | The date the image was created, as GMT. <i class="label label-info">read-only</i>                       |
 | `date_modified`     | date-time | The date the image was last modified, in the site's timezone. <i class="label label-info">read-only</i> |
@@ -157,7 +157,7 @@ This API helps you to create a new product.
 	</div>
 </div>
 
-> Example of how to create a `simple` product:
+> Example of how to create a `simple` product with one existing image and one new image:
 
 ```shell
 curl -X POST https://example.com/wp-json/wc/v3/products \
@@ -179,7 +179,7 @@ curl -X POST https://example.com/wp-json/wc/v3/products \
   ],
   "images": [
     {
-      "src": "http://demo.woothemes.com/woocommerce/wp-content/uploads/sites/56/2013/06/T_2_front.jpg"
+      "id": 42
     },
     {
       "src": "http://demo.woothemes.com/woocommerce/wp-content/uploads/sites/56/2013/06/T_2_back.jpg"
@@ -205,7 +205,7 @@ const data = {
   ],
   images: [
     {
-      src: "http://demo.woothemes.com/woocommerce/wp-content/uploads/sites/56/2013/06/T_2_front.jpg"
+	  id: 42
     },
     {
       src: "http://demo.woothemes.com/woocommerce/wp-content/uploads/sites/56/2013/06/T_2_back.jpg"
@@ -240,7 +240,7 @@ $data = [
     ],
     'images' => [
         [
-            'src' => 'http://demo.woothemes.com/woocommerce/wp-content/uploads/sites/56/2013/06/T_2_front.jpg'
+            'id': 42
         ],
         [
             'src' => 'http://demo.woothemes.com/woocommerce/wp-content/uploads/sites/56/2013/06/T_2_back.jpg'
@@ -269,7 +269,7 @@ data = {
     ],
     "images": [
         {
-            "src": "http://demo.woothemes.com/woocommerce/wp-content/uploads/sites/56/2013/06/T_2_front.jpg"
+            "id": 42
         },
         {
             "src": "http://demo.woothemes.com/woocommerce/wp-content/uploads/sites/56/2013/06/T_2_back.jpg"
@@ -297,7 +297,7 @@ data = {
   ],
   images: [
     {
-      src: "http://demo.woothemes.com/woocommerce/wp-content/uploads/sites/56/2013/06/T_2_front.jpg"
+      id: 42
     },
     {
       src: "http://demo.woothemes.com/woocommerce/wp-content/uploads/sites/56/2013/06/T_2_back.jpg",
@@ -393,11 +393,11 @@ woocommerce.post("products", data).parsed_response
   "tags": [],
   "images": [
     {
-      "id": 792,
-      "date_created": "2017-03-23T14:01:13",
-      "date_created_gmt": "2017-03-23T20:01:13",
-      "date_modified": "2017-03-23T14:01:13",
-      "date_modified_gmt": "2017-03-23T20:01:13",
+      "id": 42,
+      "date_created": "2017-03-22T14:01:13",
+      "date_created_gmt": "2017-03-22T20:01:13",
+      "date_modified": "2017-03-22T14:01:13",
+      "date_modified_gmt": "2017-03-22T20:01:13",
       "src": "https://example.com/wp-content/uploads/2017/03/T_2_front-4.jpg",
       "name": "",
       "alt": ""

--- a/source/includes/wp-api-v3/_refunds.md
+++ b/source/includes/wp-api-v3/_refunds.md
@@ -152,7 +152,7 @@ woocommerce.get("refunds").parsed_response
 | `include`        | array   | Limit result set to specific ids.                                                                                            |
 | `offset`         | integer | Offset the result set by a specific number of items.                                                                         |
 | `order`          | string  | Order sort attribute ascending or descending. Options: `asc` and `desc`. Default is `desc`.                                  |
-| `orderby`        | string  | Sort collection by object attribute. Options: `date`, `id`, `include`, `title` and `slug`. Default is `date`.                |
+| `orderby`        | string  | Sort collection by object attribute. Options: `date`, `modified`, `id`, `include`, `title` and `slug`. Default is `date`.    |
 | `parent`         | array   | Limit result set to those of particular parent IDs.                                                                          |
 | `parent_exclude` | array   | Limit result set to all items except those of a particular parent ID.                                                        |
 | `dp`             | integer | Number of decimal points to use in each resource. Default is `2`.                                                            |

--- a/source/includes/wp-api-v3/_refunds.md
+++ b/source/includes/wp-api-v3/_refunds.md
@@ -1,0 +1,158 @@
+# Refunds #
+
+The refunds API is a simple, read-only endpoint that allows you to retrieve a list of refunds outside the context of an existing order. To create, view, and delete individual refunds, check out the [order refunds API](#order-refunds).
+
+## Refund properties ##
+
+All properties are the same as those in the [order refunds endpoint](#order-refund-properties), but with one additional property:
+
+| Attribute   | Type    | Description                                        |
+|-------------|---------|----------------------------------------------------|
+| `parent_id` | integer | The ID of the order the refund is associated with. |
+
+## Retrieve a list of refunds ##
+
+This API lets you retrieve and view refunds from your store, regardless of which order they are associated with.
+
+### HTTP request ###
+
+<div class="api-endpoint">
+	<div class="endpoint-data">
+		<i class="label label-get">GET</i>
+		<h6>/wp-json/wc/v3/refunds</h6>
+	</div>
+</div>
+
+```shell
+curl https://example.com/wp-json/wc/v3/refunds \
+	-u consumer_key:consumer_secret
+```
+
+```javascript
+WooCommerce.get("refunds")
+  .then((response) => {
+    console.log(response.data);
+  })
+  .catch((error) => {
+    console.log(error.response.data);
+  });
+```
+
+```php
+<?php print_r($woocommerce->get('refunds')); ?>
+```
+
+```python
+print(wcapi.get("refunds").json())
+```
+
+```ruby
+woocommerce.get("refunds").parsed_response
+```
+
+> JSON response example:
+
+```json
+[
+	{
+		"id": 726,
+        "parent_id": 124,
+		"date_created": "2017-03-21T17:07:11",
+		"date_created_gmt": "2017-03-21T20:07:11",
+		"amount": "10.00",
+		"reason": "",
+		"refunded_by": 1,
+		"refunded_payment": false,
+		"meta_data": [],
+		"line_items": [],
+		"_links": {
+			"self": [
+				{
+					"href": "https://example.com/wp-json/wc/v3/orders/723/refunds/726"
+				}
+			],
+			"collection": [
+				{
+					"href": "https://example.com/wp-json/wc/v3/orders/723/refunds"
+				}
+			],
+			"up": [
+				{
+					"href": "https://example.com/wp-json/wc/v3/orders/723"
+				}
+			]
+		}
+	},
+	{
+		"id": 724,
+        "parent_id": 63,
+		"date_created": "2017-03-21T16:55:37",
+		"date_created_gmt": "2017-03-21T19:55:37",
+		"amount": "9.00",
+		"reason": "",
+		"refunded_by": 1,
+		"refunded_payment": false,
+		"meta_data": [],
+		"line_items": [
+			{
+				"id": 314,
+				"name": "Woo Album #2",
+				"product_id": 87,
+				"variation_id": 0,
+				"quantity": -1,
+				"tax_class": "",
+				"subtotal": "-9.00",
+				"subtotal_tax": "0.00",
+				"total": "-9.00",
+				"total_tax": "0.00",
+				"taxes": [],
+				"meta_data": [
+					{
+						"id": 2076,
+						"key": "_refunded_item_id",
+						"value": "311"
+					}
+				],
+				"sku": "",
+				"price": -9
+			}
+		],
+		"_links": {
+			"self": [
+				{
+					"href": "https://example.com/wp-json/wc/v3/orders/723/refunds/724"
+				}
+			],
+			"collection": [
+				{
+					"href": "https://example.com/wp-json/wc/v3/orders/723/refunds"
+				}
+			],
+			"up": [
+				{
+					"href": "https://example.com/wp-json/wc/v3/orders/723"
+				}
+			]
+		}
+	}
+]
+```
+
+#### Available parameters ####
+
+| Parameter        | Type    | Description                                                                                                                  |
+|------------------|---------|------------------------------------------------------------------------------------------------------------------------------|
+| `context`        | string  | Scope under which the request is made; determines fields present in response. Options: `view` and `edit`. Default is `view`. |
+| `page`           | integer | Current page of the collection. Default is `1`.                                                                              |
+| `per_page`       | integer | Maximum number of items to be returned in result set. Default is `10`.                                                       |
+| `search`         | string  | Limit results to those matching a string.                                                                                    |
+| `after`          | string  | Limit response to resources published after a given ISO8601 compliant date.                                                  |
+| `before`         | string  | Limit response to resources published before a given ISO8601 compliant date.                                                 |
+| `exclude`        | array   | Ensure result set excludes specific IDs.                                                                                     |
+| `include`        | array   | Limit result set to specific ids.                                                                                            |
+| `offset`         | integer | Offset the result set by a specific number of items.                                                                         |
+| `order`          | string  | Order sort attribute ascending or descending. Options: `asc` and `desc`. Default is `desc`.                                  |
+| `orderby`        | string  | Sort collection by object attribute. Options: `date`, `id`, `include`, `title` and `slug`. Default is `date`.                |
+| `parent`         | array   | Limit result set to those of particular parent IDs.                                                                          |
+| `parent_exclude` | array   | Limit result set to all items except those of a particular parent ID.                                                        |
+| `dp`             | integer | Number of decimal points to use in each resource. Default is `2`.                                                            |

--- a/source/includes/wp-api-v3/_system-status.md
+++ b/source/includes/wp-api-v3/_system-status.md
@@ -16,38 +16,38 @@ The system status API allows you to view all system status items.
 
 ### System status - Environment properties ###
 
-| Attribute                   | Type    | Description                                                                |
-| --------------------------- | ------- | -------------------------------------------------------------------------- |
-| `home_url`                  | string  | Home URL. <i class="label label-info">read-only</i>                        |
-| `site_url`                  | string  | Site URL. <i class="label label-info">read-only</i>                        |
-| `wc_version`                | string  | WooCommerce version. <i class="label label-info">read-only</i>             |
-| `log_directory`             | string  | Log directory. <i class="label label-info">read-only</i>                   |
-| `log_directory_writable`    | boolean | Is log directory writable? <i class="label label-info">read-only</i>       |
-| `wp_version`                | string  | WordPress version. <i class="label label-info">read-only</i>               |
-| `wp_multisite`              | boolean | Is WordPress multisite? <i class="label label-info">read-only</i>          |
-| `wp_memory_limit`           | integer | WordPress memory limit. <i class="label label-info">read-only</i>          |
-| `wp_debug_mode`             | boolean | Is WordPress debug mode active? <i class="label label-info">read-only</i>  |
-| `wp_cron`                   | boolean | Are WordPress cron jobs enabled? <i class="label label-info">read-only</i> |
-| `language`                  | string  | WordPress language. <i class="label label-info">read-only</i>              |
-| `server_info`               | string  | Server info. <i class="label label-info">read-only</i>                     |
-| `php_version`               | string  | PHP version. <i class="label label-info">read-only</i>                     |
-| `php_post_max_size`         | integer | PHP post max size. <i class="label label-info">read-only</i>               |
-| `php_max_execution_time`    | integer | PHP max execution time. <i class="label label-info">read-only</i>          |
-| `php_max_input_vars`        | integer | PHP max input vars. <i class="label label-info">read-only</i>              |
-| `curl_version`              | string  | cURL version. <i class="label label-info">read-only</i>                    |
-| `suhosin_installed`         | boolean | Is SUHOSIN installed? <i class="label label-info">read-only</i>            |
-| `max_upload_size`           | integer | Max upload size. <i class="label label-info">read-only</i>                 |
-| `mysql_version`             | string  | MySQL version. <i class="label label-info">read-only</i>                   |
-| `default_timezone`          | string  | Default timezone. <i class="label label-info">read-only</i>                |
+| Attribute                | Type    | Description                                                                |
+| ------------------------ | ------- | -------------------------------------------------------------------------- |
+| `home_url`               | string  | Home URL. <i class="label label-info">read-only</i>                        |
+| `site_url`               | string  | Site URL. <i class="label label-info">read-only</i>                        |
+| `version`                | string  | WooCommerce version. <i class="label label-info">read-only</i>             |
+| `log_directory`          | string  | Log directory. <i class="label label-info">read-only</i>                   |
+| `log_directory_writable` | boolean | Is log directory writable? <i class="label label-info">read-only</i>       |
+| `wp_version`             | string  | WordPress version. <i class="label label-info">read-only</i>               |
+| `wp_multisite`           | boolean | Is WordPress multisite? <i class="label label-info">read-only</i>          |
+| `wp_memory_limit`        | integer | WordPress memory limit. <i class="label label-info">read-only</i>          |
+| `wp_debug_mode`          | boolean | Is WordPress debug mode active? <i class="label label-info">read-only</i>  |
+| `wp_cron`                | boolean | Are WordPress cron jobs enabled? <i class="label label-info">read-only</i> |
+| `language`               | string  | WordPress language. <i class="label label-info">read-only</i>              |
+| `server_info`            | string  | Server info. <i class="label label-info">read-only</i>                     |
+| `php_version`            | string  | PHP version. <i class="label label-info">read-only</i>                     |
+| `php_post_max_size`      | integer | PHP post max size. <i class="label label-info">read-only</i>               |
+| `php_max_execution_time` | integer | PHP max execution time. <i class="label label-info">read-only</i>          |
+| `php_max_input_vars`     | integer | PHP max input vars. <i class="label label-info">read-only</i>              |
+| `curl_version`           | string  | cURL version. <i class="label label-info">read-only</i>                    |
+| `suhosin_installed`      | boolean | Is SUHOSIN installed? <i class="label label-info">read-only</i>            |
+| `max_upload_size`        | integer | Max upload size. <i class="label label-info">read-only</i>                 |
+| `mysql_version`          | string  | MySQL version. <i class="label label-info">read-only</i>                   |
+| `default_timezone`       | string  | Default timezone. <i class="label label-info">read-only</i>                |
 | `fsockopen_or_curl_enabled` | boolean | Is fsockopen/cURL enabled? <i class="label label-info">read-only</i>       |
-| `soapclient_enabled`        | boolean | Is SoapClient class enabled? <i class="label label-info">read-only</i>     |
-| `domdocument_enabled`       | boolean | Is DomDocument class enabled? <i class="label label-info">read-only</i>    |
-| `gzip_enabled`              | boolean | Is GZip enabled? <i class="label label-info">read-only</i>                 |
-| `mbstring_enabled`          | boolean | Is mbstring enabled? <i class="label label-info">read-only</i>             |
-| `remote_post_successful`    | boolean | Remote POST successful? <i class="label label-info">read-only</i>          |
-| `remote_post_response`      | string  | Remote POST response. <i class="label label-info">read-only</i>            |
-| `remote_get_successful`     | boolean | Remote GET successful? <i class="label label-info">read-only</i>           |
-| `remote_get_response`       | string  | Remote GET response. <i class="label label-info">read-only</i>             |
+| `soapclient_enabled`     | boolean | Is SoapClient class enabled? <i class="label label-info">read-only</i>     |
+| `domdocument_enabled`    | boolean | Is DomDocument class enabled? <i class="label label-info">read-only</i>    |
+| `gzip_enabled`           | boolean | Is GZip enabled? <i class="label label-info">read-only</i>                 |
+| `mbstring_enabled`       | boolean | Is mbstring enabled? <i class="label label-info">read-only</i>             |
+| `remote_post_successful` | boolean | Remote POST successful? <i class="label label-info">read-only</i>          |
+| `remote_post_response`   | string  | Remote POST response. <i class="label label-info">read-only</i>            |
+| `remote_get_successful`  | boolean | Remote GET successful? <i class="label label-info">read-only</i>           |
+| `remote_get_response`    | string  | Remote GET response. <i class="label label-info">read-only</i>             |
 
 ### System status - Database properties ###
 

--- a/source/includes/wp-api-v3/_taxes.md
+++ b/source/includes/wp-api-v3/_taxes.md
@@ -4,22 +4,22 @@ The taxes API allows you to create, view, update, and delete individual tax rate
 
 ## Tax rate properties ##
 
-| Attribute  |   Type  |                                                                                   Description                                                                                   |
-|------------|---------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `id`       | integer | Unique identifier for the resource. <i class="label label-info">read-only</i>                                                                                                   |
-| `country`  | string  | Country ISO 3166 code. See [ISO 3166 Codes (Countries)](http://www.chemie.fu-berlin.de/diverse/doc/ISO_3166.html) for more details                                              |
-| `state`    | string  | State code.                                                                                                                                                                     |
-| `postcode` | string  | Postcode/ZIP, it doesn't support multiple values. Deprecated as of WooCommerce 5.3, `postcodes` should be used instead.                                                         |
-| `city`     | string  | City name, it doesn't support multiple values. Deprecated as of WooCommerce 5.3, `postcodes` should be used instead.                                                            |
-| `postcodes`| string[]  | Postcodes/ZIPs. Introduced in WooCommerce 5.3.                                                                                                                                |
-| `cities`   | string[]  | City names. Introduced in WooCommerce 5.3.                                                                                                                                    |
-| `rate`     | string  | Tax rate.                                                                                                                                                                       |
-| `name`     | string  | Tax rate name.                                                                                                                                                                  |
+| Attribute  |   Type  | Description                                                                                                                                                                    |
+|------------|---------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `id`       | integer | Unique identifier for the resource. <i class="label label-info">read-only</i>                                                                                                  |
+| `country`  | string  | Country ISO 3166 code. See [ISO 3166 Codes (Countries)](http://www.chemie.fu-berlin.de/diverse/doc/ISO_3166.html) for more details                                             |
+| `state`    | string  | State code.                                                                                                                                                                    |
+| `postcode` | string  | Postcode/ZIP, it doesn't support multiple values. Deprecated as of WooCommerce 5.3, `postcodes` should be used instead.                                                        |
+| `city`     | string  | City name, it doesn't support multiple values. Deprecated as of WooCommerce 5.3, `postcodes` should be used instead.                                                           |
+| `postcodes`| string[]  | Postcodes/ZIPs. Introduced in WooCommerce 5.3.                                                                                                                                 |
+| `cities`   | string[]  | City names. Introduced in WooCommerce 5.3.                                                                                                                                     |
+| `rate`     | string  | Tax rate.                                                                                                                                                                      |
+| `name`     | string  | Tax rate name.                                                                                                                                                                 |
 | `priority` | integer | Tax priority. Only 1 matching rate per priority will be used. To define multiple tax rates for a single area you need to specify a different priority per rate. Default is `1`. |
-| `compound` | boolean | Whether or not this is a compound rate. Compound tax rates are applied on top of other tax rates. Default is `false`.                                                           |
-| `shipping` | boolean | Whether or not this tax rate also gets applied to shipping. Default is `true`.                                                                                                  |
-| `order`    | integer | Indicates the order that will appear in queries.                                                                                                                                |
-| `class`    | string  | Tax class. Default is `standard`.                                                                                                                                               |
+| `compound` | boolean | Whether or not this is a compound tax rate. Compound rates are applied on top of other tax rates. Default is `false`.                                                       |
+| `shipping` | boolean | Whether or not this tax rate also gets applied to shipping. Default is `true`.                                                                                                 |
+| `order`    | integer | Indicates the order that will appear in queries.                                                                                                                               |
+| `class`    | string  | Tax class. Default is `standard`.                                                                                                                                              |
 
 ## Create a tax rate ##
 

--- a/source/includes/wp-api-v3/_webhooks.md
+++ b/source/includes/wp-api-v3/_webhooks.md
@@ -366,19 +366,19 @@ woocommerce.get("webhooks").parsed_response
 
 #### Available parameters ####
 
-| Parameter  | Type    | Description                                                                                                                   |
-| ---------- | ------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| `context`  | string  | Scope under which the request is made; determines fields present in response. Options: `view` and `edit`. Default is `view`.  |
-| `page`     | integer | Current page of the collection. Default is `1`.                                                                               |
-| `per_page` | integer | Maximum number of items to be returned in result set. Default is `10`.                                                        |
-| `search`   | string  | Limit results to those matching a string.                                                                                     |
-| `after`    | string  | Limit response to resources published after a given ISO8601 compliant date.                                                   |
-| `before`   | string  | Limit response to resources published before a given ISO8601 compliant date.                                                  |
-| `exclude`  | array   | Ensure result set excludes specific IDs.                                                                                      |
-| `include`  | array   | Limit result set to specific ids.                                                                                             |
-| `offset`   | integer | Offset the result set by a specific number of items.                                                                          |
-| `order`    | string  | Order sort attribute ascending or descending. Options: `asc` and `desc`. Default is `desc`.                                   |
-| `orderby`  | string  | Sort collection by object attribute. Options: `date`, `id`, `include`, `title` and `slug`. Default is `date`.                 |
+| Parameter  | Type    | Description                                                                                                                  |
+| ---------- | ------- |------------------------------------------------------------------------------------------------------------------------------|
+| `context`  | string  | Scope under which the request is made; determines fields present in response. Options: `view` and `edit`. Default is `view`. |
+| `page`     | integer | Current page of the collection. Default is `1`.                                                                              |
+| `per_page` | integer | Maximum number of items to be returned in result set. Default is `10`.                                                       |
+| `search`   | string  | Limit results to those matching a string.                                                                                    |
+| `after`    | string  | Limit response to resources published after a given ISO8601 compliant date.                                                  |
+| `before`   | string  | Limit response to resources published before a given ISO8601 compliant date.                                                 |
+| `exclude`  | array   | Ensure result set excludes specific IDs.                                                                                     |
+| `include`  | array   | Limit result set to specific ids.                                                                                            |
+| `offset`   | integer | Offset the result set by a specific number of items.                                                                         |
+| `order`    | string  | Order sort attribute ascending or descending. Options: `asc` and `desc`. Default is `desc`.                                  |
+| `orderby`  | string  | Sort collection by object attribute. Options: `date`, `id`, and `title`. Default is `date`.                        |
 | `status`   | string  | Limit result set to webhooks assigned a specific status. Options: `all`, `active`, `paused` and `disabled`. Default is `all`. |
 
 ## Update a webhook ##

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -35,6 +35,7 @@ includes:
   - wp-api-v3/product-tags
   - wp-api-v3/product-reviews
   - wp-api-v3/reports
+  - wp-api-v3/refunds
   - wp-api-v3/taxes
   - wp-api-v3/tax-classes
   - wp-api-v3/webhooks


### PR DESCRIPTION
There are several issues in the backlog of the [REST API focus](https://github.com/woocommerce/woocommerce/labels/focus%3A%20rest%20api) in the WooCommerce repo. This attempts to batch fixes for those issues into one PR.

- [x] https://github.com/woocommerce/woocommerce/issues/43444
- [x] https://github.com/woocommerce/woocommerce/pull/46895 (add documentation for new refunds endpoint)
- [x] https://github.com/woocommerce/woocommerce/issues/28474
- [x] https://github.com/woocommerce/woocommerce/issues/45924
- [x] https://github.com/woocommerce/woocommerce/issues/45836
- [x] https://github.com/woocommerce/woocommerce/issues/43647
- [x] https://github.com/woocommerce/woocommerce/issues/35619
- [x] https://github.com/woocommerce/woocommerce/issues/32037

### To test

* After checking out this PR branch, run the script to build the static docs site files: `./build.sh`. This will create a `build` directory in the repo.
* Find the `index.html` file in the build directory and open it in a browser. You should see something that looks just like the [live REST API docs site](https://woocommerce.github.io/woocommerce-rest-api-docs/).
* Check for typos and other formatting issues related to the changes in this PR.
