### PR TITLE
Add product custom fields documentation

### DIFF
--- a/source/includes/wp-api-v3/_product-custom-fields.md
+++ b/source/includes/wp-api-v3/_product-custom-fields.md
@@ -1,0 +1,61 @@
+# Product custom fields #
+
+The product custom fields API allows you to view the custom fields that have been recorded.
+
+## Product custom fields properties ##
+
+| Attribute | Type   | Description                                                                                                 |
+| --------- | ------ | ----------------------------------------------------------------------------------------------------------- |
+| `key`     | string | The custom field key.                                                                                       |
+| `value`   | string | The value set for the key.                                                                                  |
+
+## Retrieve product custom fields ##
+
+This API lets you retrieve filtered custom fields.
+
+<div class="api-endpoint">
+	<div class="endpoint-data">
+		<i class="label label-get">GET</i>
+		<h6>/wp-json//wc/v3/products/custom-fields/names</h6>
+	</div>
+</div>
+
+```shell
+curl https://example.com/wp-json/wc/v3/products/custom-fields/names \
+	-u consumer_key:consumer_secret
+```
+
+```javascript
+WooCommerce.get("products/custom-fields/names")
+  .then((response) => {
+    console.log(response.data);
+  })
+  .catch((error) => {
+    console.log(error.response.data);
+  });
+```
+
+```php
+<?php print_r($woocommerce->get('products/custom-fields/names')); ?>
+```
+
+```python
+print(wcapi.get("products/custom-fields/names").json())
+```
+
+```ruby
+woocommerce.get("products/custom-fields/names").parsed_response
+```
+
+> JSON response example:
+
+```json
+{
+	[
+		"Custom field 1",
+		"Custom field 2",
+		"Custom field 3",
+		"Custom field 4"
+	]
+}
+```

--- a/source/includes/wp-api-v3/_product-custom-fields.md
+++ b/source/includes/wp-api-v3/_product-custom-fields.md
@@ -6,13 +6,11 @@ The product custom fields API allows you to view the custom field names that hav
 
 | Parameter  | Type     | Description                                                                                                                  |
 | ---------- | -------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| `context`  | string  | Scope under which the request is made; determines fields present in response. Options: `view` and `edit`. Default is `view`. |
-| `page`     | integer | Current page of the collection. Default is `1`.                                                                              |
-| `per_page` | integer | Maximum number of items to be returned in result set. Default is `10`.                                                       |
-| `search`   | string  | Limit results to those matching a string.                                                                                    |
-| `exclude`  | array   | Ensure result set excludes specific IDs.                                                                                     |
-| `include`  | array   | Limit result set to specific ids.                                                                                            |
-| `order`    | string  | Order sort attribute ascending or descending. Options: `asc` and `desc`. Default is `desc`.                                  |
+| `context`  | string   | Scope under which the request is made; determines fields present in response. Options: `view` and `edit`. Default is `view`. |
+| `page`     | integer  | Current page of the collection. Default is `1`.                                                                              |
+| `per_page` | integer  | Maximum number of items to be returned in result set. Default is `10`.                                                       |
+| `search`   | string   | Limit results to those matching a string.                                                                                    |
+| `order`    | string   | Order sort attribute ascending or descending. Options: `asc` and `desc`. Default is `desc`.                                  |
 
 ## Retrieve product custom field names ##
 

--- a/source/includes/wp-api-v3/_product-custom-fields.md
+++ b/source/includes/wp-api-v3/_product-custom-fields.md
@@ -2,10 +2,10 @@
 
 The product custom fields API allows you to view the custom field names that have been recorded.
 
-## Available parameters ##
+## Custom fields available parameters ##
 
-| Parameter | Type     | Description                                                                                                                  |
-| --------- | -------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| Parameter  | Type     | Description                                                                                                                  |
+| ---------- | -------- | ---------------------------------------------------------------------------------------------------------------------------- |
 | `context`  | string  | Scope under which the request is made; determines fields present in response. Options: `view` and `edit`. Default is `view`. |
 | `page`     | integer | Current page of the collection. Default is `1`.                                                                              |
 | `per_page` | integer | Maximum number of items to be returned in result set. Default is `10`.                                                       |

--- a/source/includes/wp-api-v3/_product-custom-fields.md
+++ b/source/includes/wp-api-v3/_product-custom-fields.md
@@ -2,12 +2,17 @@
 
 The product custom fields API allows you to view the custom field names that have been recorded.
 
-## Product custom fields properties ##
+## Available parameters ##
 
-| Attribute | Type   | Description                                                                                                 |
-| --------- | ------ | ----------------------------------------------------------------------------------------------------------- |
-| `key`     | string | The custom field key.                                                                                       |
-| `value`   | string | The value set for the key.                                                                                  |
+| Parameter | Type     | Description                                                                                                                  |
+| --------- | -------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `context`  | string  | Scope under which the request is made; determines fields present in response. Options: `view` and `edit`. Default is `view`. |
+| `page`     | integer | Current page of the collection. Default is `1`.                                                                              |
+| `per_page` | integer | Maximum number of items to be returned in result set. Default is `10`.                                                       |
+| `search`   | string  | Limit results to those matching a string.                                                                                    |
+| `exclude`  | array   | Ensure result set excludes specific IDs.                                                                                     |
+| `include`  | array   | Limit result set to specific ids.                                                                                            |
+| `order`    | string  | Order sort attribute ascending or descending. Options: `asc` and `desc`. Default is `desc`.                                  |
 
 ## Retrieve product custom field names ##
 
@@ -16,7 +21,7 @@ This API lets you retrieve filtered custom field names.
 <div class="api-endpoint">
 	<div class="endpoint-data">
 		<i class="label label-get">GET</i>
-		<h6>/wp-json//wc/v3/products/custom-fields/names</h6>
+		<h6>/wp-json/wc/v3/products/custom-fields/names</h6>
 	</div>
 </div>
 

--- a/source/includes/wp-api-v3/_product-custom-fields.md
+++ b/source/includes/wp-api-v3/_product-custom-fields.md
@@ -1,6 +1,6 @@
 # Product custom fields #
 
-The product custom fields API allows you to view the custom fields that have been recorded.
+The product custom fields API allows you to view the custom field names that have been recorded.
 
 ## Product custom fields properties ##
 
@@ -9,9 +9,9 @@ The product custom fields API allows you to view the custom fields that have bee
 | `key`     | string | The custom field key.                                                                                       |
 | `value`   | string | The value set for the key.                                                                                  |
 
-## Retrieve product custom fields ##
+## Retrieve product custom field names ##
 
-This API lets you retrieve filtered custom fields.
+This API lets you retrieve filtered custom field names.
 
 <div class="api-endpoint">
 	<div class="endpoint-data">

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -31,6 +31,7 @@ includes:
   - wp-api-v3/product-attributes
   - wp-api-v3/product-attribute-terms
   - wp-api-v3/product-categories
+  - wp-api-v3/product-custom-fields
   - wp-api-v3/product-shipping-classes
   - wp-api-v3/product-tags
   - wp-api-v3/product-reviews


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The WooCommerce PR https://github.com/woocommerce/woocommerce/pull/48504 added a new REST API endpoint meant to get the `product custom field` names.

Closes https://github.com/woocommerce/woocommerce/issues/46921

This PR adds the documentation necessary for that new endpoint.

### How to test the changes in this Pull Request:

1. Checkout this branch and build the project
```
sh build.sh
```
2. After running the build process, you will see a `build` folder in your project.
3. Go to the `build` folder and open the file `./index.html` in your browser.
4. Go to `Product custom fields` in the sidebar.
5. Verify that the documentation looks correct.