### PR TITLE
Orders: Add doc for order actions

### DIFF
--- a/source/includes/wp-api-v3/_order-actions.md
+++ b/source/includes/wp-api-v3/_order-actions.md
@@ -2,7 +2,7 @@
 
 The order actions API allows you to perform specific actions with existing orders like you can from the Edit Order screen in the web app.
 
-_Note: currently only one action is available, other actions will introduced at a later time._
+_Note: currently only one action is available, other actions will be introduced at a later time._
 
 ## Send order details to customer ##
 

--- a/source/includes/wp-api-v3/_order-actions.md
+++ b/source/includes/wp-api-v3/_order-actions.md
@@ -1,0 +1,65 @@
+# Order actions #
+
+The order actions API allows you to perform specific actions with existing orders like you can from the Edit Order screen in the web app.
+
+_Note: currently only one action is available, other actions will introduced at a later time._
+
+## Send order details to customer ##
+
+This endpoint allows you to trigger an email to the customer with the details of their order, if the order contains a customer email address.
+
+### HTTP request ###
+
+<div class="api-endpoint">
+	<div class="endpoint-data">
+		<i class="label label-post">POST</i>
+		<h6>/wp-json/wc/v3/orders/&lt;id&gt;/actions/send_order_details</h6>
+	</div>
+</div>
+
+```shell
+curl -X POST https://example.com/wp-json/wc/v3/orders/723/actions/send_order_details \
+	-u consumer_key:consumer_secret
+```
+
+```javascript
+WooCommerce.post("orders/723/actions/send_order_details")
+  .then((response) => {
+    console.log(response.data);
+  })
+  .catch((error) => {
+    console.log(error.response.data);
+  });
+```
+
+```php
+<?php
+print_r($woocommerce->post('orders/723/actions/send_order_details'));
+?>
+```
+
+```python
+print(wcapi.post("orders/723/actions/send_order_details").json())
+```
+
+```ruby
+woocommerce.post("orders/723/actions/send_order_details").parsed_response
+```
+
+> JSON response examples:
+
+```json
+{
+  "message": "Order details sent to woo@example.com, via REST API."
+}
+```
+
+```json
+{
+	"code": "woocommerce_rest_missing_email",
+	"message": "Order does not have an email address.",
+	"data": {
+		"status": 400
+	}
+}
+```

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -24,6 +24,7 @@ includes:
   - wp-api-v3/coupons
   - wp-api-v3/customers
   - wp-api-v3/orders
+  - wp-api-v3/order-actions
   - wp-api-v3/order-notes
   - wp-api-v3/order-refunds
   - wp-api-v3/products


### PR DESCRIPTION
Adds documentation for the REST endpoint introduced in https://github.com/woocommerce/woocommerce/pull/52050

Fixes #251 

## To test

1. Run the build script found in the root of this repo: `./build.sh`
2. Find the `build` directory created by the script, and the `index.html` file within. Load that file in your web browser.
3. Look for the new "Order actions" item in the left-side menu. Read the text and the code examples and make sure it all makes sense and there aren't any typos!