### PR TITLE
Brand update - colors 

### DIFF
--- a/source/stylesheets/_lang-selector.scss
+++ b/source/stylesheets/_lang-selector.scss
@@ -4,11 +4,11 @@
     padding: 10px 20px;
 
     &:active, &:focus, &:hover {
-      border-top-color: #9B5C8F;
+      border-top-color: #873EFF;
     }
 
     &.active {
-      border-top-color: #9B5C8F;
+      border-top-color: #873EFF;
     }
   }
 }

--- a/source/stylesheets/_variables.scss
+++ b/source/stylesheets/_variables.scss
@@ -28,18 +28,18 @@ $examples-bg: #393939 !default;
 $code-bg: #292929 !default;
 $code-annotation-bg: #191D1F !default;
 $nav-subitem-bg: #f7f7f7 !default;
-$nav-active-bg: #7f54b3 !default;
+$nav-active-bg: #6108CE !default;
 $nav-active-parent-bg: #f7f7f7 !default; // parent links of the current section
 $lang-select-border: #000 !default;
 $lang-select-bg: #222 !default;
 $lang-select-active-bg: $examples-bg !default; // feel free to change this to blue or something
 $lang-select-pressed-bg: #111 !default; // color of language tab bg when mouse is pressed
 $main-bg: #ffffff !default;
-$aside-notice-bg: #7f54b3 !default;
+$aside-notice-bg: #6108CE !default;
 $aside-warning-bg: #ca4949 !default;
 $aside-success-bg: #38a845 !default;
 $search-notice-bg: #c97a7e !default;
-$link-color: #7f54b3;
+$link-color: #6108CE;
 
 
 // TEXT COLORS


### PR DESCRIPTION
This PR updates the colors in the REST API docs:

**Before**
<img width="500" alt="Screenshot 2025-02-04 at 10 21 11" src="https://github.com/user-attachments/assets/a7a66b98-775f-49e9-93c5-25bbfbeafcac" />

**After**
<img width="500" alt="Screenshot 2025-02-04 at 10 21 39" src="https://github.com/user-attachments/assets/360e3eb4-21ed-4cf3-beb7-d20a6bfb3646" />
