### PR TITLE
Create tax hint about tax class link

### DIFF
--- a/source/includes/v3/_taxes.md
+++ b/source/includes/v3/_taxes.md
@@ -42,7 +42,8 @@ curl -X POST https://example.com/wc-api/v3/taxes \
     "state": "AL",
     "rate": "4",
     "name": "State Tax",
-    "shipping": false
+    "shipping": false,
+    "class": "standard"
   }
 }'
 ```


### PR DESCRIPTION
This gives the user a hint that they can pass inn "class" in the body to link it to a tax class.