### PR TITLE
Add new fields to image attributes in products documentation

### DIFF
--- a/source/includes/v3/_products.md
+++ b/source/includes/v3/_products.md
@@ -97,6 +97,9 @@ This section lists all API endpoints that can be used to create, edit or otherwi
 | `title`      | string  | Image title (attachment title)                                                         |
 | `alt`        | string  | Image alt text (attachment image alt text)                                             |
 | `position`   | integer | Image position. `0` means that the image is featured                                   |
+| `srcset`     | string  | Image srcset for responsive images <i class="label label-info">read-only</i>          |
+| `sizes`      | string  | Image sizes attribute for responsive images <i class="label label-info">read-only</i> |
+| `thumbnail`  | string  | Thumbnail image URL <i class="label label-info">read-only</i>                         |
 
 <aside class="notice">
 	<code>alt</code> and <code>title</code> attributes are writable starting from WooCommerce 2.5.


### PR DESCRIPTION
### Summary

This PR updates the WooCommerce REST API v3 documentation to reflect new image metadata properties added to the Products controller. This documentation update aligns with the improvements made in [woocommerce/woocommerce#60074](https://github.com/woocommerce/woocommerce/pull/60074).

### Changes Made

Added three new image metadata properties to the **Images Properties** section in the Products REST API v3 documentation:

- **`srcset`** - Image srcset for responsive images (read-only)
- **`sizes`** - Image sizes attribute for responsive images (read-only)  
- **`thumbnail`** - Thumbnail image URL (read-only)

⚠️ Only merge once 10.2 is released after September 15, 2025 ⚠️