### PR TITLE
Additional link to new Java API client library in the 'Third party libraries' section

### DIFF
--- a/source/includes/wp-api-v3/_introduction.md
+++ b/source/includes/wp-api-v3/_introduction.md
@@ -255,6 +255,7 @@ woocommerce = WooCommerce::API.new(
 
 ### Third party libraries ###
 
+- [Java](https://github.com/wtx-labs/woocommerce-api-client-java) Library
 - [Java](https://github.com/icoderman/wc-api-java) Library
 - [.NET](https://github.com/XiaoFaye/WooCommerce.NET) Library
 - [Android](https://github.com/gilokimu/WooDroid) Library


### PR DESCRIPTION
## Changes
- As the developer of the new Java API Client library, added entry to Third Party Tools section.
- Library fully covers WooCommerce REST API, enabling seamless Java app integration (e.g., Spring Boot).

## Why This Addition
- Ready-to-use client for all API endpoints: authentication, products, orders, customers, etc.
- Simplifies WooCommerce integration for Java backends.
- This API client library is definitely more convenient and modern than the one currently mentioned in the documentation - see details on the project's GitHub page: https://github.com/wtx-labs/woocommerce-api-client-java