### PR TITLE
Replace 'Leather Shoes' example product tag with 'Canvas Sneakers'

### DIFF
--- a/source/includes/v3/_product-tags.md
+++ b/source/includes/v3/_product-tags.md
@@ -33,7 +33,7 @@ curl -X POST https://example.com/wc-api/v3/products/tags \
 	-H "Content-Type: application/json" \
 	-d '{
   "product_tag": {
-    "name": "Leather Shoes"
+    "name": "Canvas Sneakers"
   }
 }'
 ```
@@ -41,7 +41,7 @@ curl -X POST https://example.com/wc-api/v3/products/tags \
 ```javascript
 var data = {
   product_tag: {
-    name: 'Leather Shoes'
+    name: 'Canvas Sneakers'
   }
 };
 
@@ -54,7 +54,7 @@ WooCommerce.post('products/tags', data, function(err, data, res) {
 <?php
 $data = [
     'product_tag': [
-        'name' => 'Leather Shoes'
+        'name' => 'Canvas Sneakers'
     ]
 ];
 
@@ -65,7 +65,7 @@ print_r($woocommerce->post('products/tags', $data));
 ```python
 data = {
     "product_tag": {
-        "name": "Leather Shoes"
+        "name": "Canvas Sneakers"
     }
 }
 
@@ -75,7 +75,7 @@ print(wcapi.post("products/tags", data).json())
 ```ruby
 data = {
   product_tag: {
-    name: "Leather Shoes"
+    name: "Canvas Sneakers"
   }
 }
 
@@ -88,8 +88,8 @@ woocommerce.post("products/tags", data).parsed_response
 {
   "product_tag": {
     "id": 37,
-    "name": "Leather Shoes",
-    "slug": "leather-shoes",
+    "name": "Canvas Sneakers",
+    "slug": "canvas-sneakers",
     "description": "",
     "count": 0
   }
@@ -140,8 +140,8 @@ woocommerce.get("products/tags/37").parsed_response
 {
   "product_tag": {
     "id": 37,
-    "name": "Leather Shoes",
-    "slug": "leather-shoes",
+    "name": "Canvas Sneakers",
+    "slug": "canvas-sneakers",
     "description": "",
     "count": 0
   }
@@ -193,8 +193,8 @@ woocommerce.get("products/tags").parsed_response
   "product_tags": [
     {
       "id": 37,
-      "name": "Leather Shoes",
-      "slug": "leather-shoes",
+      "name": "Canvas Sneakers",
+      "slug": "canvas-sneakers",
       "description": "",
       "count": 0
     },
@@ -232,7 +232,7 @@ curl -X PUT https://example.com/wc-api/v3/products/tags/37 \
 	-H "Content-Type: application/json" \
 	-d '{
   "product_tag": {
-    "description": "Genuine leather."
+    "description": "Ethically sourced materials."
   }
 }'
 ```
@@ -240,7 +240,7 @@ curl -X PUT https://example.com/wc-api/v3/products/tags/37 \
 ```javascript
 var data = {
   product_tag: {
-    description: 'Genuine leather.'
+    description: 'Ethically sourced materials.'
   }
 };
 
@@ -253,7 +253,7 @@ WooCommerce.put('products/tags/37', data, function(err, data, res) {
 <?php
 $data = [
     'product_tag': [
-        'description': 'Genuine leather.'
+        'description': 'Ethically sourced materials.'
     ]
 ];
 
@@ -264,7 +264,7 @@ print_r($woocommerce->put('products/tags/37', $data));
 ```python
 data = {
     "product_tag": {
-        "description": "Genuine leather."
+        "description": "Ethically sourced materials."
     }
 }
 
@@ -274,7 +274,7 @@ print(wcapi.put("products/tags/37", data).json())
 ```ruby
 data = {
   product_tag: {
-    description: "Genuine leather."
+    description: "Ethically sourced materials."
   }
 }
 
@@ -287,9 +287,9 @@ woocommerce.put("products/tags/37", data).parsed_response
 {
   "product_tag": {
     "id": 37,
-    "name": "Leather Shoes",
-    "slug": "leather-shoes",
-    "description": "Genuine leather.",
+    "name": "Canvas Sneakers",
+    "slug": "canvas-sneakers",
+    "description": "Ethically sourced materials.",
     "count": 0
   }
 }

--- a/source/includes/wp-api-v1/_introduction.md
+++ b/source/includes/wp-api-v1/_introduction.md
@@ -88,7 +88,7 @@ woocommerce.get("products/tags/34", _jsonp: "tagDetails").parsed_response
 > Response:
 
 ```
-/**/tagDetails({"id":34,"name":"Leather Shoes","slug":"leather-shoes","description":"","count":0,"_links":{"self":[{"href":"https://example.com/wp-json/wc/v1/products/tags/34"}],"collection":[{"href":"https://example.com/wp-json/wc/v1/products/tags"}]}})%
+/**/tagDetails({"id":34,"name":"Canvas Sneakers","slug":"canvas-sneakers","description":"","count":0,"_links":{"self":[{"href":"https://example.com/wp-json/wc/v1/products/tags/34"}],"collection":[{"href":"https://example.com/wp-json/wc/v1/products/tags"}]}})%
 ```
 
 ## Errors ##

--- a/source/includes/wp-api-v1/_product-tags.md
+++ b/source/includes/wp-api-v1/_product-tags.md
@@ -32,13 +32,13 @@ curl -X POST https://example.com/wp-json/wc/v1/products/tags \
 	-u consumer_key:consumer_secret \
 	-H "Content-Type: application/json" \
 	-d '{
-  "name": "Leather Shoes"
+  "name": "Canvas Sneakers"
 }'
 ```
 
 ```javascript
 const data = {
-  name: "Leather Shoes"
+  name: "Canvas Sneakers"
 };
 
 WooCommerce.post("products/tags", data)
@@ -53,7 +53,7 @@ WooCommerce.post("products/tags", data)
 ```php
 <?php
 $data = [
-    'name' => 'Leather Shoes'
+    'name' => 'Canvas Sneakers'
 ];
 
 print_r($woocommerce->post('products/tags', $data));
@@ -62,7 +62,7 @@ print_r($woocommerce->post('products/tags', $data));
 
 ```python
 data = {
-    "name": "Leather Shoes"
+    "name": "Canvas Sneakers"
 }
 
 print(wcapi.post("products/tags", data).json())
@@ -70,7 +70,7 @@ print(wcapi.post("products/tags", data).json())
 
 ```ruby
 data = {
-  name: "Leather Shoes"
+  name: "Canvas Sneakers"
 }
 
 woocommerce.post("products/tags", data).parsed_response
@@ -81,8 +81,8 @@ woocommerce.post("products/tags", data).parsed_response
 ```json
 {
   "id": 34,
-  "name": "Leather Shoes",
-  "slug": "leather-shoes",
+  "name": "Canvas Sneakers",
+  "slug": "canvas-sneakers",
   "description": "",
   "count": 0,
   "_links": {
@@ -143,8 +143,8 @@ woocommerce.get("products/tags/34").parsed_response
 ```json
 {
   "id": 34,
-  "name": "Leather Shoes",
-  "slug": "leather-shoes",
+  "name": "Canvas Sneakers",
+  "slug": "canvas-sneakers",
   "description": "",
   "count": 0,
   "_links": {
@@ -206,8 +206,8 @@ woocommerce.get("products/tags").parsed_response
 [
   {
     "id": 34,
-    "name": "Leather Shoes",
-    "slug": "leather-shoes",
+    "name": "Canvas Sneakers",
+    "slug": "canvas-sneakers",
     "description": "",
     "count": 0,
     "_links": {
@@ -279,13 +279,13 @@ curl -X PUT https://example.com/wp-json/wc/v1/products/tags/34 \
 	-u consumer_key:consumer_secret \
 	-H "Content-Type: application/json" \
 	-d '{
-  "description": "Genuine leather."
+  "description": "Ethically sourced materials."
 }'
 ```
 
 ```javascript
 const data = {
-  description: "Genuine leather."
+  description: "Ethically sourced materials."
 };
 
 WooCommerce.put("products/tags/34", data)
@@ -300,7 +300,7 @@ WooCommerce.put("products/tags/34", data)
 ```php
 <?php
 $data = [
-    'description': 'Genuine leather.'
+    'description': 'Ethically sourced materials.'
 ];
 
 print_r($woocommerce->put('products/tags/34', $data));
@@ -309,7 +309,7 @@ print_r($woocommerce->put('products/tags/34', $data));
 
 ```python
 data = {
-    "description": "Genuine leather."
+    "description": "Ethically sourced materials."
 }
 
 print(wcapi.put("products/tags/34", data).json())
@@ -317,7 +317,7 @@ print(wcapi.put("products/tags/34", data).json())
 
 ```ruby
 data = {
-  description: "Genuine leather."
+  description: "Ethically sourced materials."
 }
 
 woocommerce.put("products/tags/34", data).parsed_response
@@ -328,9 +328,9 @@ woocommerce.put("products/tags/34", data).parsed_response
 ```json
 {
   "id": 34,
-  "name": "Leather Shoes",
-  "slug": "leather-shoes",
-  "description": "Genuine leather.",
+  "name": "Canvas Sneakers",
+  "slug": "canvas-sneakers",
+  "description": "Ethically sourced materials.",
   "count": 0,
   "_links": {
     "self": [
@@ -394,9 +394,9 @@ woocommerce.delete("products/tags/34", force: true).parsed_response
 ```json
 {
   "id": 34,
-  "name": "Leather Shoes",
-  "slug": "leather-shoes",
-  "description": "Genuine leather.",
+  "name": "Canvas Sneakers",
+  "slug": "canvas-sneakers",
+  "description": "Ethically sourced materials.",
   "count": 0,
   "_links": {
     "self": [
@@ -452,7 +452,7 @@ curl -X POST https://example.com//wp-json/wc/v1/products/tags/batch \
   "update": [
     {
       "id": 34,
-      "description": "Genuine leather."
+      "description": "Ethically sourced materials."
     }
   ],
   "delete": [
@@ -474,7 +474,7 @@ const data = {
   update: [
     {
       id: 34,
-      description: "Genuine leather."
+      description: "Ethically sourced materials."
     }
   ],
   delete: [
@@ -505,7 +505,7 @@ $data = [
     'update' => [
         [
             'id' => 34,
-            'description' => 'Genuine leather.'
+            'description' => 'Ethically sourced materials.'
         ]
     ],
     'delete' => [
@@ -530,7 +530,7 @@ data = {
     "update": [
         {
             "id": 34,
-            "description": "Genuine leather."
+            "description": "Ethically sourced materials."
         }
     ],
     "delete": [
@@ -554,7 +554,7 @@ data = {
   update: [
     {
       id: 34,
-      description: "Genuine leather."
+      description: "Ethically sourced materials."
     }
   ],
   delete: [
@@ -612,9 +612,9 @@ woocommerce.post("products/tags/batch", data).parsed_response
   "update": [
     {
       "id": 34,
-      "name": "Leather Shoes",
-      "slug": "leather-shoes",
-      "description": "Genuine leather.",
+      "name": "Canvas Sneakers",
+      "slug": "canvas-sneakers",
+      "description": "Ethically sourced materials.",
       "count": 0,
       "_links": {
         "self": [

--- a/source/includes/wp-api-v2/_introduction.md
+++ b/source/includes/wp-api-v2/_introduction.md
@@ -87,7 +87,7 @@ woocommerce.get("products/tags/34", _jsonp: "tagDetails").parsed_response
 > Response:
 
 ```
-/**/tagDetails({"id":34,"name":"Leather Shoes","slug":"leather-shoes","description":"","count":0,"_links":{"self":[{"href":"https://example.com/wp-json/wc/v2/products/tags/34"}],"collection":[{"href":"https://example.com/wp-json/wc/v2/products/tags"}]}})%
+/**/tagDetails({"id":34,"name":"Canvas Sneakers","slug":"canvas-sneakers","description":"","count":0,"_links":{"self":[{"href":"https://example.com/wp-json/wc/v2/products/tags/34"}],"collection":[{"href":"https://example.com/wp-json/wc/v2/products/tags"}]}})%
 ```
 
 ## Errors ##

--- a/source/includes/wp-api-v2/_product-tags.md
+++ b/source/includes/wp-api-v2/_product-tags.md
@@ -32,13 +32,13 @@ curl -X POST https://example.com/wp-json/wc/v2/products/tags \
 	-u consumer_key:consumer_secret \
 	-H "Content-Type: application/json" \
 	-d '{
-  "name": "Leather Shoes"
+  "name": "Canvas Sneakers"
 }'
 ```
 
 ```javascript
 const data = {
-  name: "Leather Shoes"
+  name: "Canvas Sneakers"
 };
 
 WooCommerce.post("products/tags", data)
@@ -53,7 +53,7 @@ WooCommerce.post("products/tags", data)
 ```php
 <?php
 $data = [
-    'name' => 'Leather Shoes'
+    'name' => 'Canvas Sneakers'
 ];
 
 print_r($woocommerce->post('products/tags', $data));
@@ -62,7 +62,7 @@ print_r($woocommerce->post('products/tags', $data));
 
 ```python
 data = {
-    "name": "Leather Shoes"
+    "name": "Canvas Sneakers"
 }
 
 print(wcapi.post("products/tags", data).json())
@@ -70,7 +70,7 @@ print(wcapi.post("products/tags", data).json())
 
 ```ruby
 data = {
-  name: "Leather Shoes"
+  name: "Canvas Sneakers"
 }
 
 woocommerce.post("products/tags", data).parsed_response
@@ -81,8 +81,8 @@ woocommerce.post("products/tags", data).parsed_response
 ```json
 {
   "id": 34,
-  "name": "Leather Shoes",
-  "slug": "leather-shoes",
+  "name": "Canvas Sneakers",
+  "slug": "canvas-sneakers",
   "description": "",
   "count": 0,
   "_links": {
@@ -143,8 +143,8 @@ woocommerce.get("products/tags/34").parsed_response
 ```json
 {
   "id": 34,
-  "name": "Leather Shoes",
-  "slug": "leather-shoes",
+  "name": "Canvas Sneakers",
+  "slug": "canvas-sneakers",
   "description": "",
   "count": 0,
   "_links": {
@@ -206,8 +206,8 @@ woocommerce.get("products/tags").parsed_response
 [
   {
     "id": 34,
-    "name": "Leather Shoes",
-    "slug": "leather-shoes",
+    "name": "Canvas Sneakers",
+    "slug": "canvas-sneakers",
     "description": "",
     "count": 0,
     "_links": {
@@ -280,13 +280,13 @@ curl -X PUT https://example.com/wp-json/wc/v2/products/tags/34 \
 	-u consumer_key:consumer_secret \
 	-H "Content-Type: application/json" \
 	-d '{
-  "description": "Genuine leather."
+  "description": "Ethically sourced materials."
 }'
 ```
 
 ```javascript
 const data = {
-  description: "Genuine leather."
+  description: "Ethically sourced materials."
 };
 
 WooCommerce.put("products/tags/34", data)
@@ -301,7 +301,7 @@ WooCommerce.put("products/tags/34", data)
 ```php
 <?php
 $data = [
-    'description': 'Genuine leather.'
+    'description': 'Ethically sourced materials.'
 ];
 
 print_r($woocommerce->put('products/tags/34', $data));
@@ -310,7 +310,7 @@ print_r($woocommerce->put('products/tags/34', $data));
 
 ```python
 data = {
-    "description": "Genuine leather."
+    "description": "Ethically sourced materials."
 }
 
 print(wcapi.put("products/tags/34", data).json())
@@ -318,7 +318,7 @@ print(wcapi.put("products/tags/34", data).json())
 
 ```ruby
 data = {
-  description: "Genuine leather."
+  description: "Ethically sourced materials."
 }
 
 woocommerce.put("products/tags/34", data).parsed_response
@@ -329,9 +329,9 @@ woocommerce.put("products/tags/34", data).parsed_response
 ```json
 {
   "id": 34,
-  "name": "Leather Shoes",
-  "slug": "leather-shoes",
-  "description": "Genuine leather.",
+  "name": "Canvas Sneakers",
+  "slug": "canvas-sneakers",
+  "description": "Ethically sourced materials.",
   "count": 0,
   "_links": {
     "self": [
@@ -395,9 +395,9 @@ woocommerce.delete("products/tags/34", force: true).parsed_response
 ```json
 {
   "id": 34,
-  "name": "Leather Shoes",
-  "slug": "leather-shoes",
-  "description": "Genuine leather.",
+  "name": "Canvas Sneakers",
+  "slug": "canvas-sneakers",
+  "description": "Ethically sourced materials.",
   "count": 0,
   "_links": {
     "self": [
@@ -453,7 +453,7 @@ curl -X POST https://example.com//wp-json/wc/v2/products/tags/batch \
   "update": [
     {
       "id": 34,
-      "description": "Genuine leather."
+      "description": "Ethically sourced materials."
     }
   ],
   "delete": [
@@ -475,7 +475,7 @@ const data = {
   update: [
     {
       id: 34,
-      description: "Genuine leather."
+      description: "Ethically sourced materials."
     }
   ],
   delete: [
@@ -506,7 +506,7 @@ $data = [
     'update' => [
         [
             'id' => 34,
-            'description' => 'Genuine leather.'
+            'description' => 'Ethically sourced materials.'
         ]
     ],
     'delete' => [
@@ -531,7 +531,7 @@ data = {
     "update": [
         {
             "id": 34,
-            "description": "Genuine leather."
+            "description": "Ethically sourced materials."
         }
     ],
     "delete": [
@@ -555,7 +555,7 @@ data = {
   update: [
     {
       id: 34,
-      description: "Genuine leather."
+      description: "Ethically sourced materials."
     }
   ],
   delete: [
@@ -613,9 +613,9 @@ woocommerce.post("products/tags/batch", data).parsed_response
   "update": [
     {
       "id": 34,
-      "name": "Leather Shoes",
-      "slug": "leather-shoes",
-      "description": "Genuine leather.",
+      "name": "Canvas Sneakers",
+      "slug": "canvas-sneakers",
+      "description": "Ethically sourced materials.",
       "count": 0,
       "_links": {
         "self": [

--- a/source/includes/wp-api-v3/_introduction.md
+++ b/source/includes/wp-api-v3/_introduction.md
@@ -88,7 +88,7 @@ woocommerce.get("products/tags/34", _jsonp: "tagDetails").parsed_response
 > Response:
 
 ```
-/**/tagDetails({"id":34,"name":"Leather Shoes","slug":"leather-shoes","description":"","count":0,"_links":{"self":[{"href":"https://example.com/wp-json/wc/v3/products/tags/34"}],"collection":[{"href":"https://example.com/wp-json/wc/v3/products/tags"}]}})%
+/**/tagDetails({"id":34,"name":"Canvas Sneakers","slug":"canvas-sneakers","description":"","count":0,"_links":{"self":[{"href":"https://example.com/wp-json/wc/v3/products/tags/34"}],"collection":[{"href":"https://example.com/wp-json/wc/v3/products/tags"}]}})%
 ```
 
 ## Errors ##

--- a/source/includes/wp-api-v3/_product-tags.md
+++ b/source/includes/wp-api-v3/_product-tags.md
@@ -32,13 +32,13 @@ curl -X POST https://example.com/wp-json/wc/v3/products/tags \
 	-u consumer_key:consumer_secret \
 	-H "Content-Type: application/json" \
 	-d '{
-  "name": "Leather Shoes"
+  "name": "Canvas Sneakers"
 }'
 ```
 
 ```javascript
 const data = {
-  name: "Leather Shoes"
+  name: "Canvas Sneakers"
 };
 
 WooCommerce.post("products/tags", data)
@@ -53,7 +53,7 @@ WooCommerce.post("products/tags", data)
 ```php
 <?php
 $data = [
-    'name' => 'Leather Shoes'
+    'name' => 'Canvas Sneakers'
 ];
 
 print_r($woocommerce->post('products/tags', $data));
@@ -62,7 +62,7 @@ print_r($woocommerce->post('products/tags', $data));
 
 ```python
 data = {
-    "name": "Leather Shoes"
+    "name": "Canvas Sneakers"
 }
 
 print(wcapi.post("products/tags", data).json())
@@ -70,7 +70,7 @@ print(wcapi.post("products/tags", data).json())
 
 ```ruby
 data = {
-  name: "Leather Shoes"
+  name: "Canvas Sneakers"
 }
 
 woocommerce.post("products/tags", data).parsed_response
@@ -81,8 +81,8 @@ woocommerce.post("products/tags", data).parsed_response
 ```json
 {
   "id": 34,
-  "name": "Leather Shoes",
-  "slug": "leather-shoes",
+  "name": "Canvas Sneakers",
+  "slug": "canvas-sneakers",
   "description": "",
   "count": 0,
   "_links": {
@@ -143,8 +143,8 @@ woocommerce.get("products/tags/34").parsed_response
 ```json
 {
   "id": 34,
-  "name": "Leather Shoes",
-  "slug": "leather-shoes",
+  "name": "Canvas Sneakers",
+  "slug": "canvas-sneakers",
   "description": "",
   "count": 0,
   "_links": {
@@ -206,8 +206,8 @@ woocommerce.get("products/tags").parsed_response
 [
   {
     "id": 34,
-    "name": "Leather Shoes",
-    "slug": "leather-shoes",
+    "name": "Canvas Sneakers",
+    "slug": "canvas-sneakers",
     "description": "",
     "count": 0,
     "_links": {
@@ -280,13 +280,13 @@ curl -X PUT https://example.com/wp-json/wc/v3/products/tags/34 \
 	-u consumer_key:consumer_secret \
 	-H "Content-Type: application/json" \
 	-d '{
-  "description": "Genuine leather."
+  "description": "Ethically sourced materials."
 }'
 ```
 
 ```javascript
 const data = {
-  description: "Genuine leather."
+  description: "Ethically sourced materials."
 };
 
 WooCommerce.put("products/tags/34", data)
@@ -301,7 +301,7 @@ WooCommerce.put("products/tags/34", data)
 ```php
 <?php
 $data = [
-    'description': 'Genuine leather.'
+    'description': 'Ethically sourced materials.'
 ];
 
 print_r($woocommerce->put('products/tags/34', $data));
@@ -310,7 +310,7 @@ print_r($woocommerce->put('products/tags/34', $data));
 
 ```python
 data = {
-    "description": "Genuine leather."
+    "description": "Ethically sourced materials."
 }
 
 print(wcapi.put("products/tags/34", data).json())
@@ -318,7 +318,7 @@ print(wcapi.put("products/tags/34", data).json())
 
 ```ruby
 data = {
-  description: "Genuine leather."
+  description: "Ethically sourced materials."
 }
 
 woocommerce.put("products/tags/34", data).parsed_response
@@ -329,9 +329,9 @@ woocommerce.put("products/tags/34", data).parsed_response
 ```json
 {
   "id": 34,
-  "name": "Leather Shoes",
-  "slug": "leather-shoes",
-  "description": "Genuine leather.",
+  "name": "Canvas Sneakers",
+  "slug": "canvas-sneakers",
+  "description": "Ethically sourced materials.",
   "count": 0,
   "_links": {
     "self": [
@@ -395,9 +395,9 @@ woocommerce.delete("products/tags/34", force: true).parsed_response
 ```json
 {
   "id": 34,
-  "name": "Leather Shoes",
-  "slug": "leather-shoes",
-  "description": "Genuine leather.",
+  "name": "Canvas Sneakers",
+  "slug": "canvas-sneakers",
+  "description": "Ethically sourced materials.",
   "count": 0,
   "_links": {
     "self": [
@@ -453,7 +453,7 @@ curl -X POST https://example.com//wp-json/wc/v3/products/tags/batch \
   "update": [
     {
       "id": 34,
-      "description": "Genuine leather."
+      "description": "Ethically sourced materials."
     }
   ],
   "delete": [
@@ -475,7 +475,7 @@ const data = {
   update: [
     {
       id: 34,
-      description: "Genuine leather."
+      description: "Ethically sourced materials."
     }
   ],
   delete: [
@@ -506,7 +506,7 @@ $data = [
     'update' => [
         [
             'id' => 34,
-            'description' => 'Genuine leather.'
+            'description' => 'Ethically sourced materials.'
         ]
     ],
     'delete' => [
@@ -531,7 +531,7 @@ data = {
     "update": [
         {
             "id": 34,
-            "description": "Genuine leather."
+            "description": "Ethically sourced materials."
         }
     ],
     "delete": [
@@ -555,7 +555,7 @@ data = {
   update: [
     {
       id: 34,
-      description: "Genuine leather."
+      description: "Ethically sourced materials."
     }
   ],
   delete: [
@@ -613,9 +613,9 @@ woocommerce.post("products/tags/batch", data).parsed_response
   "update": [
     {
       "id": 34,
-      "name": "Leather Shoes",
-      "slug": "leather-shoes",
-      "description": "Genuine leather.",
+      "name": "Canvas Sneakers",
+      "slug": "canvas-sneakers",
+      "description": "Ethically sourced materials.",
       "count": 0,
       "_links": {
         "self": [


### PR DESCRIPTION
## Summary

Updates example product tag data across all API version docs:
- Leather Shoes to Canvas Sneakers
- leather-shoes to canvas-sneakers
- Genuine leather. to Ethically sourced materials.

This is a documentation-only change to example placeholder data. No functional or API behavior changes. The update modernizes the example product to use a neutral, non-animal-derived product reference. Canvas Sneakers works equally well as an illustrative product tag for WooCommerce diverse global merchant base.

## Files changed

- source/includes/wp-api-v3/_product-tags.md
- source/includes/wp-api-v2/_product-tags.md
- source/includes/wp-api-v1/_product-tags.md
- source/includes/v3/_product-tags.md
- source/includes/wp-api-v3/_introduction.md
- source/includes/wp-api-v2/_introduction.md
- source/includes/wp-api-v1/_introduction.md