### PR TITLE
Replace crazy-max/ghaction-github-pages with official GitHub Pages actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,21 +3,35 @@ on:
   push:
     branches:
       - trunk
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
 jobs:
   build-and-deploy:
     if: github.repository_owner == 'woocommerce'
     name: Build and deploy
     runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Build
       run: ./build.sh
-    - name: Deploy to GitHub Pages
-      if: success()
-      uses: crazy-max/ghaction-github-pages@59173cb633d9a3514f5f4552a6a3e62c6710355c # v2
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Setup Pages
+      uses: actions/configure-pages@v5
+    - name: Upload artifact
+      uses: actions/upload-pages-artifact@v3
       with:
-        target_branch: gh-pages
-        build_dir: build
+        path: build
+    - name: Deploy to GitHub Pages
+      id: deployment
+      uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- Replaces the third-party `crazy-max/ghaction-github-pages` action with the official `actions/upload-pages-artifact` + `actions/deploy-pages` actions
- Updates `actions/checkout` from v2 to v4
- Adds required `permissions`, `concurrency`, and `environment` configuration for the official Pages deployment workflow

## Notes
- The repository's Pages source setting may need to be changed from "Deploy from a branch" to "GitHub Actions" in Settings > Pages for this to work
- Addresses [QAO-31](https://linear.app/a8c/issue/QAO-31)

## Test plan
- [ ] Verify the repo's Pages source is set to "GitHub Actions" in Settings > Pages
- [ ] Merge to trunk and confirm the deploy workflow runs successfully
- [ ] Confirm the site is accessible at its GitHub Pages URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)