### PR TITLE
Add markdown endpoints for AI coding agents

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,6 +26,8 @@ jobs:
       uses: actions/checkout@v4
     - name: Build
       run: ./build.sh
+    - name: Generate markdown for AI agents
+      run: ./build-markdown.sh
     - name: Setup Pages
       uses: actions/configure-pages@v5
     - name: Upload artifact

--- a/build-markdown.sh
+++ b/build-markdown.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# Generate combined markdown files for AI agents
+# These are smaller alternatives to the full HTML documentation
+
+set -e
+
+generate_markdown() {
+    local source_file="$1"
+    local output_file="$2"
+    local title="$3"
+
+    echo "Generating $output_file..."
+
+    echo "# $title" > "$output_file"
+    echo "" >> "$output_file"
+
+    # Parse YAML front matter to get includes
+    # Extract lines between "includes:" and the next YAML key (lines starting with a letter)
+    includes=$(sed -n '/^includes:/,/^[a-z]/p' "$source_file" | grep "^\s*-" | sed 's/.*- //')
+
+    for include in $includes; do
+        # Convert include path to file path
+        # e.g., "wp-api-v3/introduction" -> "source/includes/wp-api-v3/_introduction.md"
+        dir=$(dirname "$include")
+        base=$(basename "$include")
+        include_file="source/includes/${dir}/_${base}.md"
+
+        if [ -f "$include_file" ]; then
+            cat "$include_file" >> "$output_file"
+            echo "" >> "$output_file"
+        else
+            echo "Warning: Include file not found: $include_file"
+        fi
+    done
+
+    # Report file size
+    size=$(wc -c < "$output_file" | tr -d ' ')
+    echo "  Generated: $output_file ($(numfmt --to=iec-i --suffix=B $size 2>/dev/null || echo "${size} bytes"))"
+}
+
+mkdir -p build
+
+# Generate each version
+generate_markdown "source/index.html.md" "build/index.md" "WooCommerce REST API Documentation (WP REST API v3)"
+generate_markdown "source/wp-api-v1.html.md" "build/wp-api-v1.md" "WooCommerce REST API Documentation (WP REST API v1)"
+generate_markdown "source/wp-api-v2.html.md" "build/wp-api-v2.md" "WooCommerce REST API Documentation (WP REST API v2)"
+
+echo ""
+echo "Markdown files generated in build/"


### PR DESCRIPTION

### Summary
- Add a build script to generate lightweight markdown versions of the API docs
- Update deploy workflow to generate markdown files alongside HTML
- New endpoints: `/index.md`, `/wp-api-v1.md`, `/wp-api-v2.md`

### Problem

The current `index.html` is **4.2 MB**, which is heavy for AI coding agents and LLMs to fetch and process. Agents don't need syntax highlighting, language tabs, or interactive features—they just need the raw documentation content.

### Solution

Generate combined markdown files at build time by parsing the YAML front matter from each source file and concatenating the includes in order.

### File Size Comparison

| Endpoint | Format | Size | Reduction |
|----------|--------|------|-----------|
| `/index.html` | HTML | 4.2 MB | — |
| `/index.md` | Markdown | 1.1 MB | **~74%** |
| `/wp-api-v1.md` | Markdown | 655 KB | — |
| `/wp-api-v2.md` | Markdown | 1.1 MB | — |

### Workflow Changes

The deploy workflow now runs an additional step after the Slate build:

```yaml
- name: Build
  run: ./build.sh
- name: Generate markdown for AI agents    # NEW
  run: ./build-markdown.sh
- name: Setup Pages
  ...
```

### Files Changed

| File | Change |
|------|--------|
| `build-markdown.sh` | New script to generate combined markdown |
| `.github/workflows/deploy.yml` | Added markdown generation step |

### Test Plan

- [ ] Run `./build-markdown.sh` locally
- [ ] Verify all 3 `.md` files exist in `build/`
- [ ] Confirm file sizes are ~1MB or less
- [ ] Verify markdown includes all sections in correct order
- [ ] Check that code blocks and tables are properly formatted
