### PR TITLE
Adds notice with redirect to the updated REST API docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
-# WooCommerce REST API Docs #
+# WooCommerce REST API Docs (DEPRECATED) #
 
-Repository of documentation REST API WooCommerce.
+> **NOTICE:** This repository is deprecated and only exists to serve legacy API documentation.
+>
+> The WooCommerce REST API documentation is now managed in the [WooCommerce monorepo](https://github.com/woocommerce/woocommerce/tree/trunk/docs/apis/rest-api).
+>
+> **View the current documentation at:** https://developer.woocommerce.com/docs/apis/rest-api/
+
+---
 
 This project is based on [Slate](https://github.com/tripit/slate).
 

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -1,6 +1,8 @@
 ---
 title: WooCommerce REST API Documentation - WP REST API v3
 
+redirect: https://developer.woocommerce.com/docs/apis/rest-api/
+
 language_tabs:
   - shell: cURL
   - javascript: Node.js

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -53,4 +53,6 @@ includes:
   - wp-api-v3/data
 
 search: false
+
+warning: <i class="info"></i> This documentation has moved. <a href="https://developer.woocommerce.com/docs/apis/rest-api/">View the new WooCommerce REST API documentation</a>.
 ---

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -29,6 +29,9 @@ under the License.
     <meta charset="utf-8">
     <meta content="IE=edge,chrome=1" http-equiv="X-UA-Compatible">
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+    <% if current_page.data.redirect %>
+    <meta http-equiv="refresh" content="0; url=<%= current_page.data.redirect %>">
+    <% end %>
     <title><%= current_page.data.title || "API Documentation" %></title>
 
     <link rel="icon" href="images/favicon-32x32.png" sizes="32x32" />

--- a/source/wp-api-v1.html.md
+++ b/source/wp-api-v1.html.md
@@ -1,6 +1,8 @@
 ---
 title: WooCommerce REST API Documentation - WP REST API v1
 
+redirect: https://developer.woocommerce.com/docs/apis/rest-api/
+
 language_tabs:
   - shell: cURL
   - javascript: Node.js

--- a/source/wp-api-v1.html.md
+++ b/source/wp-api-v1.html.md
@@ -38,5 +38,5 @@ includes:
 
 search: false
 
-warning: <i class="info"></i> This documentation is for the WooCommerce REST API v1 which is deprecated since WooCommerce 3.0. <a href="http://woocommerce.github.io/woocommerce-rest-api-docs/">Please use the latest REST API version</a>.
+warning: <i class="info"></i> This documentation has moved. <a href="https://developer.woocommerce.com/docs/apis/rest-api/">View the new WooCommerce REST API documentation</a>.
 ---

--- a/source/wp-api-v2.html.md
+++ b/source/wp-api-v2.html.md
@@ -47,4 +47,6 @@ includes:
   - wp-api-v2/system-status-tools
 
 search: false
+
+warning: <i class="info"></i> This documentation has moved. <a href="https://developer.woocommerce.com/docs/apis/rest-api/">View the new WooCommerce REST API documentation</a>.
 ---

--- a/source/wp-api-v2.html.md
+++ b/source/wp-api-v2.html.md
@@ -1,6 +1,8 @@
 ---
 title: WooCommerce REST API Documentation - WP REST API v2
 
+redirect: https://developer.woocommerce.com/docs/apis/rest-api/
+
 language_tabs:
   - shell: cURL
   - javascript: Node.js


### PR DESCRIPTION
We're migrating the Woo REST API docs into the monorepo. This PR adds a deprecation notice with a link to the new REST API docs.

https://github.com/woocommerce/woocommerce/pull/63630