### PR TITLE
Pin GitHub Actions to full commit SHAs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,15 +23,15 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
     - name: Build
       run: ./build.sh
     - name: Setup Pages
-      uses: actions/configure-pages@v5
+      uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
     - name: Upload artifact
-      uses: actions/upload-pages-artifact@v3
+      uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
       with:
         path: build
     - name: Deploy to GitHub Pages
       id: deployment
-      uses: actions/deploy-pages@v4
+      uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4


### PR DESCRIPTION
## Summary

WooCommerce intends to enforce full-length commit SHA pinning for GitHub Actions across the organization. This pins every remote action reference in this repository to the commit currently identified by its existing tag or branch, while retaining that human-readable ref in a comment.

Immutable action references reduce the risk that a moved or compromised upstream ref can silently change the code executed by CI, which narrows the supply-chain compromise surface.

## Validation

- Re-ran the action reference scanner in check mode; zero unpinned remote action references remain.
- Ran `git diff --check` successfully.
- Parsed every changed workflow and composite action file as YAML successfully.

## Changelog

No changelog is needed because this changes workflow/action configuration only and is not shipped to merchants.
